### PR TITLE
[FEAT] Controller(API) 테스트 코드 작성에 필요한 유틸 개발

### DIFF
--- a/src/main/java/com/genius/gitget/security/controller/AuthController.java
+++ b/src/main/java/com/genius/gitget/security/controller/AuthController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,6 +47,14 @@ public class AuthController {
 
         return ResponseEntity.ok().body(
                 new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage())
+        );
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<CommonResponse> test() {
+
+        return ResponseEntity.ok().body(
+                new CommonResponse(SUCCESS.getStatus(), "TEST 성공")
         );
     }
 }

--- a/src/test/java/com/genius/gitget/security/controller/AuthControllerTest.java
+++ b/src/test/java/com/genius/gitget/security/controller/AuthControllerTest.java
@@ -1,14 +1,11 @@
 package com.genius.gitget.security.controller;
 
-import static com.genius.gitget.security.constants.JwtRule.ACCESS_PREFIX;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.genius.gitget.security.domain.UserPrincipal;
-import com.genius.gitget.security.service.JwtService;
 import com.genius.gitget.user.domain.Role;
-import com.genius.gitget.user.domain.User;
+import com.genius.gitget.util.TokenTestUtil;
 import com.genius.gitget.util.WithMockCustomUser;
 import jakarta.servlet.http.Cookie;
 import lombok.extern.slf4j.Slf4j;
@@ -17,8 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +28,7 @@ public class AuthControllerTest {
     WebApplicationContext context;
 
     @Autowired
-    JwtService jwtService;
+    TokenTestUtil tokenTestUtil;
 
     @BeforeEach
     public void setup() {
@@ -48,14 +43,7 @@ public class AuthControllerTest {
     @WithMockCustomUser(role = Role.USER)
     public void test() throws Exception {
         //given
-        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication()
-                .getPrincipal();
-        User user = userPrincipal.getUser();
-
-        MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
-
-        String accessCookie = jwtService.generateAccessToken(httpServletResponse, user);
-        Cookie cookie = new Cookie(ACCESS_PREFIX.getValue(), accessCookie);
+        Cookie cookie = tokenTestUtil.createAccessCookie();
 
         //when&then
         mockMvc.perform(get("/api/test")

--- a/src/test/java/com/genius/gitget/security/controller/AuthControllerTest.java
+++ b/src/test/java/com/genius/gitget/security/controller/AuthControllerTest.java
@@ -1,0 +1,65 @@
+package com.genius.gitget.security.controller;
+
+import static com.genius.gitget.security.constants.JwtRule.ACCESS_PREFIX;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.genius.gitget.security.domain.UserPrincipal;
+import com.genius.gitget.security.service.JwtService;
+import com.genius.gitget.user.domain.Role;
+import com.genius.gitget.user.domain.User;
+import com.genius.gitget.util.WithMockCustomUser;
+import jakarta.servlet.http.Cookie;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@Transactional
+@Slf4j
+public class AuthControllerTest {
+    MockMvc mockMvc;
+    @Autowired
+    WebApplicationContext context;
+
+    @Autowired
+    JwtService jwtService;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    @DisplayName("anotation test")
+    @WithMockCustomUser(role = Role.USER)
+    public void test() throws Exception {
+        //given
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication()
+                .getPrincipal();
+        User user = userPrincipal.getUser();
+
+        MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
+
+        String accessCookie = jwtService.generateAccessToken(httpServletResponse, user);
+        Cookie cookie = new Cookie(ACCESS_PREFIX.getValue(), accessCookie);
+
+        //when&then
+        mockMvc.perform(get("/api/test")
+                        .cookie(cookie))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/genius/gitget/util/TokenTestUtil.java
+++ b/src/test/java/com/genius/gitget/util/TokenTestUtil.java
@@ -1,0 +1,40 @@
+package com.genius.gitget.util;
+
+import static com.genius.gitget.security.constants.JwtRule.ACCESS_PREFIX;
+
+import com.genius.gitget.security.domain.UserPrincipal;
+import com.genius.gitget.security.service.JwtService;
+import com.genius.gitget.user.domain.User;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenTestUtil {
+    private final JwtService jwtService;
+
+    public Cookie createAccessCookie() {
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication()
+                .getPrincipal();
+        User user = userPrincipal.getUser();
+
+        MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
+
+        String accessCookie = jwtService.generateAccessToken(httpServletResponse, user);
+        return new Cookie(ACCESS_PREFIX.getValue(), accessCookie);
+    }
+
+    public Cookie createRefreshCookie() {
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication()
+                .getPrincipal();
+        User user = userPrincipal.getUser();
+
+        MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
+
+        String refreshCookie = jwtService.generateRefreshToken(httpServletResponse, user);
+        return new Cookie(ACCESS_PREFIX.getValue(), refreshCookie);
+    }
+}

--- a/src/test/java/com/genius/gitget/util/WithMockCustomUser.java
+++ b/src/test/java/com/genius/gitget/util/WithMockCustomUser.java
@@ -1,0 +1,24 @@
+package com.genius.gitget.util;
+
+import com.genius.gitget.security.constants.ProviderInfo;
+import com.genius.gitget.user.domain.Role;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+    ProviderInfo providerInfo() default ProviderInfo.GITHUB;
+
+    String identifier() default "identifier";
+
+    String nickname() default "nickname";
+
+    String interest() default "BE,FE";
+
+    String information() default "information";
+
+    Role role() default Role.USER;
+}

--- a/src/test/java/com/genius/gitget/util/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/genius/gitget/util/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,52 @@
+package com.genius.gitget.util;
+
+import com.genius.gitget.security.service.CustomUserDetailsService;
+import com.genius.gitget.user.domain.Role;
+import com.genius.gitget.user.domain.User;
+import com.genius.gitget.user.dto.SignupRequest;
+import com.genius.gitget.user.repository.UserRepository;
+import com.genius.gitget.user.service.UserService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+@RequiredArgsConstructor
+@Slf4j
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+    private final UserRepository userRepository;
+    private final UserService userService;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+        User user = User.builder()
+                .providerInfo(customUser.providerInfo())
+                .identifier(customUser.identifier())
+                .role(Role.NOT_REGISTERED)
+                .build();
+
+        SignupRequest signupRequest = SignupRequest.builder()
+                .identifier(customUser.identifier())
+                .interest(List.of("FE", "BE"))
+                .nickname(customUser.nickname())
+                .information(customUser.information())
+                .build();
+
+        userRepository.save(user);
+        Long signupId = userService.signup(signupRequest);
+
+        UserDetails principal = customUserDetailsService.loadUserByUsername(String.valueOf(signupId));
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(),
+                principal.getAuthorities());
+
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(auth);
+        return securityContext;
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가

□ 기능 삭제

□ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
feat/34-auth-anotation

</br>

### 변경 사항
/auth 를 제외한 controller API 테스트 시, 권한 관련 오류로 인해 테스트가 되지 않는 버그를 수정합니다.
커스텀 어노테이션을 생성하여 테스트가 용이하도록 합니다.

 - [x] WithSecurityContextFactory<T>를 상속하여 SecurityContext에 저장할 사용자 생성하는 기능 추가
 - [x] 팩토리 코드를 통해 인증된 생성자를 쉽게 생성할 수 있는 커스텀 어노테이션 생성

</br>

### 테스트 결과

![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/ddac49fc-e3e5-4ad3-9f64-f9c5b92bb085)


</br>

### 연관된 이슈
#34 

</br>

### 리뷰 요구사항(선택)
> commit만 하고 이후에 한 번에 push해야한다는 사실을 까먹고 commit-push까지 진행했습니다 ㅎㅎ;;
> 다음에는 한 번에 push 하도록 하겠습니다!
