### PR TITLE
[FIX] JWT 재발급 관련 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/GitgetApplication.java
+++ b/src/main/java/com/genius/gitget/GitgetApplication.java
@@ -2,10 +2,11 @@ package com.genius.gitget;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 @EnableJpaAuditing
 @EnableMongoRepositories
 public class GitgetApplication {

--- a/src/main/java/com/genius/gitget/security/config/SecurityConfig.java
+++ b/src/main/java/com/genius/gitget/security/config/SecurityConfig.java
@@ -26,7 +26,7 @@ import org.springframework.web.cors.CorsUtils;
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
-    public static final String PERMITTED_URI[] = {"/v3/**", "/swagger-ui/**", "/api/auth/**"};
+    public static final String PERMITTED_URI[] = {"/v3/**", "/swagger-ui/**", "/api/auth/**", "/login"};
     private static final String PERMITTED_ROLES[] = {"USER", "ADMIN"};
     private final CustomCorsConfigurationSource customCorsConfigurationSource;
     private final CustomOAuth2UserService customOAuthService;

--- a/src/main/java/com/genius/gitget/security/config/SecurityConfig.java
+++ b/src/main/java/com/genius/gitget/security/config/SecurityConfig.java
@@ -54,8 +54,8 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 // JWT 검증 필터 추가
-//                .addFilterBefore(new JwtAuthenticationFilter(jwtService, userService),
-//                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtService, userService),
+                        UsernamePasswordAuthenticationFilter.class)
 
                 // OAuth 로그인 설정
                 .oauth2Login(customConfigurer -> customConfigurer

--- a/src/main/java/com/genius/gitget/security/controller/AuthController.java
+++ b/src/main/java/com/genius/gitget/security/controller/AuthController.java
@@ -31,6 +31,8 @@ public class AuthController {
     public ResponseEntity<CommonResponse> generateToken(HttpServletResponse response,
                                                         @RequestBody TokenRequest tokenRequest) {
         User requestUser = userService.findUserByIdentifier(tokenRequest.identifier());
+        jwtService.validateUser(requestUser);
+
         jwtService.generateAccessToken(response, requestUser);
         jwtService.generateRefreshToken(response, requestUser);
 

--- a/src/main/java/com/genius/gitget/security/service/JwtUtil.java
+++ b/src/main/java/com/genius/gitget/security/service/JwtUtil.java
@@ -2,7 +2,6 @@ package com.genius.gitget.security.service;
 
 import static com.genius.gitget.util.exception.ErrorCode.INVALID_EXPIRED_JWT;
 import static com.genius.gitget.util.exception.ErrorCode.INVALID_JWT;
-import static com.genius.gitget.util.exception.ErrorCode.TOKEN_NOT_FOUND;
 
 import com.genius.gitget.security.constants.JwtRule;
 import com.genius.gitget.security.constants.TokenStatus;
@@ -34,7 +33,7 @@ public class JwtUtil {
                     .build()
                     .parseClaimsJws(token);
             return TokenStatus.AUTHENTICATED;
-        } catch (ExpiredJwtException e) {
+        } catch (ExpiredJwtException | IllegalArgumentException e) {
             log.error(INVALID_EXPIRED_JWT.getMessage());
             return TokenStatus.EXPIRED;
         } catch (JwtException e) {
@@ -47,7 +46,7 @@ public class JwtUtil {
                 .filter(cookie -> cookie.getName().equals(tokenPrefix.getValue()))
                 .findFirst()
                 .map(Cookie::getValue)
-                .orElseThrow(() -> new BusinessException(TOKEN_NOT_FOUND));
+                .orElse("");
     }
 
     public Key getSigningKey(String secretKey) {

--- a/src/main/java/com/genius/gitget/user/domain/User.java
+++ b/src/main/java/com/genius/gitget/user/domain/User.java
@@ -56,7 +56,7 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Column(unique = true, length = 10)
+    @Column(unique = true, length = 20)
     private String nickname;
 
     private String interest;

--- a/src/main/java/com/genius/gitget/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/util/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다"),
+    NOT_AUTHENTICATED_USER(HttpStatus.BAD_REQUEST, "인증 가능한 사용자가 아닙니다."),
 
     INVALID_EXPIRED_JWT(HttpStatus.BAD_REQUEST, "이미 만료된 JWT 입니다."),
     INVALID_MALFORMED_JWT(HttpStatus.BAD_REQUEST, "JWT의 구조가 유효하지 않습니다."),
@@ -25,8 +26,7 @@ public enum ErrorCode {
 
     IMAGE_NOT_EXIST(HttpStatus.BAD_REQUEST, "Image가 존재하지 않습니다."),
     NOT_SUPPORTED_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 확장자입니다."),
-    NOT_SUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "");
-
+    NOT_SUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 타입입니다.");
 
 
     private final HttpStatus status;

--- a/src/test/java/com/genius/gitget/file/service/FileUtilTest.java
+++ b/src/test/java/com/genius/gitget/file/service/FileUtilTest.java
@@ -16,9 +16,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
+@Transactional
 @ActiveProfiles({"file"})
 class FileUtilTest {
     @Autowired

--- a/src/test/java/com/genius/gitget/file/service/FilesServiceTest.java
+++ b/src/test/java/com/genius/gitget/file/service/FilesServiceTest.java
@@ -10,14 +10,5 @@ class FilesServiceTest {
     @Autowired
     private FilesService filesService;
 
-    @Test
-    @DisplayName("")
-    public void (){
-        //given
 
-        //when
-
-        //then
-
-    }
 }

--- a/src/test/java/com/genius/gitget/hits/HitsTest.java
+++ b/src/test/java/com/genius/gitget/hits/HitsTest.java
@@ -1,5 +1,9 @@
 package com.genius.gitget.hits;
 
+import static com.genius.gitget.security.constants.ProviderInfo.GOOGLE;
+import static com.genius.gitget.user.domain.Role.ADMIN;
+import static com.genius.gitget.user.domain.Role.USER;
+
 import com.genius.gitget.hits.domain.Hits;
 import com.genius.gitget.hits.repository.HitsRepository;
 import com.genius.gitget.instance.domain.Instance;
@@ -10,25 +14,16 @@ import com.genius.gitget.topic.domain.Topic;
 import com.genius.gitget.topic.repository.TopicRepository;
 import com.genius.gitget.user.domain.User;
 import com.genius.gitget.user.repository.UserRepository;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-
-import static com.genius.gitget.security.constants.ProviderInfo.GOOGLE;
-import static com.genius.gitget.security.constants.ProviderType.NAVER;
-import static com.genius.gitget.user.domain.Role.ADMIN;
-import static com.genius.gitget.user.domain.Role.USER;
 
 @SpringBootTest
 @Transactional
-@Rollback(value = false)
-
 public class HitsTest {
 
     @Autowired
@@ -65,7 +60,7 @@ public class HitsTest {
         instance1 = Instance.builder()
                 .title("1일 1커밋")
                 .description("챌린지 세부사항입니다.")
-                .point_per_person(10)
+                .pointPerPerson(10)
                 .tags("BE, CS")
                 .progress(Progress.ACTIVITY)
                 .startedDate(LocalDateTime.now())
@@ -73,11 +68,11 @@ public class HitsTest {
                 .build();
 
         topic1 = Topic.builder()
-                    .title("1일 1커밋")
-                    .description("간단한 설명란")
-                    .point_per_person(300)
-                    .tags("BE, CS")
-                    .build();
+                .title("1일 1커밋")
+                .description("간단한 설명란")
+                .pointPerPerson(300)
+                .tags("BE, CS")
+                .build();
 
         userRepository.save(user1);
         userRepository.save(user2);

--- a/src/test/java/com/genius/gitget/security/service/JwtServiceTest.java
+++ b/src/test/java/com/genius/gitget/security/service/JwtServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-@Transactional(readOnly = true)
+@Transactional
 @Slf4j
 @ActiveProfiles({"jwt"})
 class JwtServiceTest {

--- a/src/test/java/com/genius/gitget/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/genius/gitget/user/repository/UserRepositoryTest.java
@@ -10,12 +10,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
-@Rollback(value = false)
 class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가

□ 기능 삭제

☑ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/44-fix-jwt-reissue-bug` → `main`

</br>

### 변경 사항
JWT 재발급 관련 버그 픽스했습니다.
- [x] Access-token이 만료되었을 때 검증하는 로직에서 Access-token의 존재 여부를 확인하는 로직 제거
- [x] JWT 발급 시, 해당 사용자의 Role이 User 또는 Admin일 때에만 발급이 가능하도록 하는 로직 추가
- [x] JWT 발급 실패 혹은 예외 발생 시, 무한 리다이렉트 되는 버그 픽스

</br>

### 테스트 결과


</br>

### 연관된 이슈
#44 

</br>

### 리뷰 요구사항(선택)

