### PR TITLE
[REFACTOR] 이미지/파일 요청과 응답 시 base64 인코딩하여 전달하도록 변경

### DIFF
--- a/src/main/java/com/genius/gitget/global/file/controller/FilesController.java
+++ b/src/main/java/com/genius/gitget/global/file/controller/FilesController.java
@@ -1,24 +1,22 @@
 package com.genius.gitget.global.file.controller;
 
 import static com.genius.gitget.global.util.exception.SuccessCode.CREATED;
+import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
+import com.genius.gitget.global.file.dto.FileRequest;
 import com.genius.gitget.global.file.dto.FileResponse;
 import com.genius.gitget.global.file.service.FilesService;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.Resource;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -29,22 +27,23 @@ public class FilesController {
 
     @PostMapping
     public ResponseEntity<SingleResponse<FileResponse>> uploadImage(
-            @RequestPart(value = "image") MultipartFile image,
-            @RequestPart(value = "type") String type) throws IOException {
+            @ModelAttribute FileRequest fileRequest) throws IOException {
 
-        FileResponse fileResponse = filesService.uploadFile(image, type);
+        FileResponse fileResponse = filesService.uploadFile(fileRequest.file(), fileRequest.type());
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(CREATED.getStatus(), CREATED.getMessage(), fileResponse)
         );
     }
 
-    @GetMapping(value = {"/{fileId}"},
-            produces = MediaType.IMAGE_JPEG_VALUE)
-    public ResponseEntity<Resource> downloadImage(@PathVariable(name = "fileId") Long fileId)
-            throws MalformedURLException {
+    @GetMapping(value = {"/{fileId}"})
+    public ResponseEntity<SingleResponse<FileResponse>> getImage(@PathVariable(name = "fileId") Long fileId)
+            throws IOException {
 
-        Resource urlResource = filesService.getFile(fileId);
-        return ResponseEntity.ok(urlResource);
+        FileResponse encodedFile = filesService.getEncodedFile(fileId);
+
+        return ResponseEntity.ok().body(
+                new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), encodedFile)
+        );
     }
 }

--- a/src/main/java/com/genius/gitget/global/file/dto/FileRequest.java
+++ b/src/main/java/com/genius/gitget/global/file/dto/FileRequest.java
@@ -1,0 +1,9 @@
+package com.genius.gitget.global.file.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record FileRequest(
+        MultipartFile file,
+        String type
+) {
+}

--- a/src/main/java/com/genius/gitget/global/file/dto/FileResponse.java
+++ b/src/main/java/com/genius/gitget/global/file/dto/FileResponse.java
@@ -1,4 +1,10 @@
 package com.genius.gitget.global.file.dto;
 
-public record FileResponse(Long fileId) {
+public record FileResponse(
+        Long fileId,
+        String encodedFile) {
+
+    public FileResponse(Long fileId) {
+        this(fileId, null);
+    }
 }

--- a/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
@@ -31,6 +31,7 @@ public class FileUtil {
         UrlResource urlResource = new UrlResource("file:" + files.getFileURI());
 
         byte[] encode = Base64.getEncoder().encode(urlResource.getContentAsByteArray());
+        return new String(encode, StandardCharsets.UTF_8);
     }
 
     public UploadDTO getUploadInfo(MultipartFile file, String typeStr) {

--- a/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
@@ -4,12 +4,17 @@ import static com.genius.gitget.global.util.exception.ErrorCode.IMAGE_NOT_EXIST;
 import static com.genius.gitget.global.util.exception.ErrorCode.NOT_SUPPORTED_EXTENSION;
 
 import com.genius.gitget.global.file.domain.FileType;
+import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.dto.UploadDTO;
 import com.genius.gitget.global.util.exception.BusinessException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,6 +25,12 @@ public class FileUtil {
 
     public FileUtil(@Value("${file.upload.path}") String uploadPath) {
         this.uploadPath = uploadPath;
+    }
+
+    public String encodedImage(Files files) throws IOException {
+        UrlResource urlResource = new UrlResource("file:" + files.getFileURI());
+
+        byte[] encode = Base64.getEncoder().encode(urlResource.getContentAsByteArray());
     }
 
     public UploadDTO getUploadInfo(MultipartFile file, String typeStr) {

--- a/src/main/java/com/genius/gitget/global/file/service/FilesService.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FilesService.java
@@ -41,7 +41,7 @@ public class FilesService {
                 .build();
 
         Files savedFile = filesRepository.save(file);
-        return new FileResponse(savedFile.getId());
+        return new FileResponse(savedFile.getId(), fileUtil.encodedImage(file));
     }
 
     private void saveFile(MultipartFile receivedFile, String fileURI) throws IOException {
@@ -51,6 +51,13 @@ public class FilesService {
             targetFile.mkdirs();
         }
         receivedFile.transferTo(targetFile);
+    }
+
+    public FileResponse getEncodedFile(Long fileId) throws IOException {
+        Files files = filesRepository.findById(fileId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.IMAGE_NOT_EXIST));
+
+        return new FileResponse(fileId, fileUtil.encodedImage(files));
     }
 
     public UrlResource getFile(Long fileId) throws MalformedURLException {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가

□ 기능 삭제

□ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`refactor/48-file-structure` → `main`

</br>

### 변경 사항
- [x] FE 측에서 이미지/파일 저장 요청 시, `@RequestPart`로 받던 부분을 `@ModelAttribute`로 변경하여 `form-data`를 객체에 연결시킵니다.
- [x] FE 쪽으로 이미지/파일 응답 시, Base64로 인코딩하여 전달하는 방식으로 변경합니다.
이미지 포함 시 다른 데이터를 포함하지 못했던 기존의 방식과는 달리, 이미지와 다른 데이터들을 같이 전달할 수 있게끔 합니다.

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/45851711-a8ed-4c16-ac6e-dfa051e7895e)

![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/57e3c01a-170f-4da3-b954-790af4281996)



</br>

### 연관된 이슈
#48 

</br>

### 리뷰 요구사항(선택)
