### PR TITLE
[HOTFIX] JWT Filter에서 예외 발생 시 처리하지 못하는 로직 수정

### DIFF
--- a/src/main/java/com/genius/gitget/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/genius/gitget/global/security/config/SecurityConfig.java
@@ -1,12 +1,13 @@
 package com.genius.gitget.global.security.config;
 
 
+import com.genius.gitget.challenge.user.service.UserService;
+import com.genius.gitget.global.security.filter.ExceptionHandlerFilter;
 import com.genius.gitget.global.security.filter.JwtAuthenticationFilter;
 import com.genius.gitget.global.security.handler.OAuth2FailureHandler;
 import com.genius.gitget.global.security.handler.OAuth2SuccessHandler;
 import com.genius.gitget.global.security.service.CustomOAuth2UserService;
 import com.genius.gitget.global.security.service.JwtService;
-import com.genius.gitget.challenge.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -56,6 +57,7 @@ public class SecurityConfig {
                 // JWT 검증 필터 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtService, userService),
                         UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
 
                 // OAuth 로그인 설정
                 .oauth2Login(customConfigurer -> customConfigurer

--- a/src/main/java/com/genius/gitget/global/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/genius/gitget/global/security/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,38 @@
+package com.genius.gitget.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.genius.gitget.global.util.exception.BusinessException;
+import com.genius.gitget.global.util.response.dto.CommonResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (BusinessException e) {
+            log.error("[ERROR]" + e.getMessage(), e);
+            setErrorResponse(response, e);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, BusinessException e) throws IOException {
+        CommonResponse commonResponse = new CommonResponse(e.getStatus(), e.getStatus().value(), e.getMessage());
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        response.setStatus(e.getStatus().value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        response.getWriter().write(
+                objectMapper.writeValueAsString(commonResponse)
+        );
+    }
+}

--- a/src/main/java/com/genius/gitget/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/genius/gitget/global/security/handler/OAuth2SuccessHandler.java
@@ -20,7 +20,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final String SIGNUP_URL = "http://localhost:5173/login/signup";
-    private final String MAIN_URL = "http://localhost:5173/main";
+    private final String AUTH_URL = "http://localhost:5173/auth";
     private final UserRepository userRepository;
 
     @Override
@@ -44,7 +44,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     .toUriString();
         }
 
-        return UriComponentsBuilder.fromHttpUrl(MAIN_URL)
+        return UriComponentsBuilder.fromHttpUrl(AUTH_URL)
+                .queryParam("identifier", identifier)
                 .build()
                 .toUriString();
     }

--- a/src/test/java/com/genius/gitget/global/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/genius/gitget/global/security/config/SecurityConfigTest.java
@@ -1,0 +1,57 @@
+package com.genius.gitget.global.security.config;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.genius.gitget.util.WithMockCustomUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+class SecurityConfigTest {
+    MockMvc mockMvc;
+    @Autowired
+    WebApplicationContext context;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+    }
+
+    @Test
+    @DisplayName("swagger에 해당하는 URI에 대해서는 2xx 응답이 발생해야 한다.")
+    public void should_status2xx_when_swaggerUri() throws Exception {
+        //given
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().is2xxSuccessful());
+    }
+
+    @Test
+    @DisplayName("permitAll에 해당하지 않는 URI에 대해서는 4xx 응답이 발생해야 한다.")
+    public void should_status2xx_when_uriIsPermitAll() throws Exception {
+        //given
+
+        //when&then
+        mockMvc.perform(get("/api/test"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("USER 또는 ADMIN은 일반 API를 호출했을 때, 2xx 응답이 발생해야 한다.")
+    @WithMockCustomUser
+    public void should_status2xx_when_authorizedUser() throws Exception {
+        mockMvc.perform(get("/api/test"))
+                .andExpect(status().is2xxSuccessful());
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 리포트
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`hotfix/57-JwtFilter-exception` → `main`

</br>

### 변경 사항
> `JwtAuthenticationFilter`에서 발생하는 예외(대체로 JWT 관련)에 대해 400번대 Code를 발생시켜야 하는데, 302번이 전달되어 기본 로그인 화면으로 리다이렉트 되고 있었습니다.  
> 추가적인 Filter 클래스(`ExceptionHandlerFilter`)를 통해 `JwtAuthenticationFilter`에서 발생한 예외에 따라 400번대를 전달하도록 했습니다.

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/7074b655-7d44-49eb-9aa7-9e40736d7764)


</br>

### 연관된 이슈
#57 

</br>

### 리뷰 요구사항(선택)
