### PR TITLE
[FEAT] Files 엔티티 연관관계에 대해 영속성 전이 설정

### DIFF
--- a/src/main/java/com/genius/gitget/admin/topic/domain/Topic.java
+++ b/src/main/java/com/genius/gitget/admin/topic/domain/Topic.java
@@ -1,7 +1,8 @@
 package com.genius.gitget.admin.topic.domain;
 
-import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.challenge.instance.domain.Instance;
+import com.genius.gitget.global.file.domain.Files;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,7 +16,6 @@ import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,7 +32,7 @@ public class Topic {
     @Column(name = "topic_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "files_id")
     private Files files;
 
@@ -64,7 +64,8 @@ public class Topic {
         this.description = description;
     }
 
-    public void updateNotExistInstance(String title, String description, String tags, String notice, int pointPerPerson) {
+    public void updateNotExistInstance(String title, String description, String tags, String notice,
+                                       int pointPerPerson) {
         this.title = title;
         this.description = description;
         this.tags = tags;
@@ -72,11 +73,11 @@ public class Topic {
         this.pointPerPerson = pointPerPerson;
     }
 
-    public void setFiles(Files files) {
-        this.files = files;
-    }
-
     public Optional<Files> getFiles() {
         return Optional.ofNullable(this.files);
+    }
+
+    public void setFiles(Files files) {
+        this.files = files;
     }
 }

--- a/src/main/java/com/genius/gitget/challenge/instance/domain/Instance.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/domain/Instance.java
@@ -5,6 +5,7 @@ import com.genius.gitget.admin.topic.domain.Topic;
 import com.genius.gitget.challenge.hits.domain.Hits;
 import com.genius.gitget.challenge.participantinfo.domain.ParticipantInfo;
 import com.genius.gitget.global.file.domain.Files;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -40,7 +41,7 @@ public class Instance {
     @Column(name = "instance_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "files_id")
     private Files files;
 
@@ -79,7 +80,8 @@ public class Instance {
     private LocalDateTime completedDate;
 
     @Builder
-    public Instance(String title, String description, String tags, int pointPerPerson, Progress progress, String notice, String certificationMethod,
+    public Instance(String title, String description, String tags, int pointPerPerson, Progress progress, String notice,
+                    String certificationMethod,
                     LocalDateTime startedDate, LocalDateTime completedDate) {
         this.title = title;
         this.description = description;

--- a/src/main/java/com/genius/gitget/challenge/user/domain/User.java
+++ b/src/main/java/com/genius/gitget/challenge/user/domain/User.java
@@ -5,6 +5,7 @@ import com.genius.gitget.challenge.participantinfo.domain.ParticipantInfo;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.security.constants.ProviderInfo;
 import com.genius.gitget.global.util.domain.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -35,7 +36,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "files_id")
     private Files files;
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/63-files-entity-cascade`→ `main`

</br>

### 변경 사항
Files 엔티티와 연관관계에 있는 User, Topic, Instance 엔티티에 영속성 전이 옵션과 고아 객체 옵션을 적용합니다.

</br>

### 테스트 결과


</br>

### 연관된 이슈
#63 

</br>

### 리뷰 요구사항(선택)

