### PR TITLE
[BUG] Topic 삭제 요청 시, 삭제가 되지 않는 버그

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceController.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceController.java
@@ -1,29 +1,29 @@
 package com.genius.gitget.challenge.instance.controller;
 
-import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceCreateRequest;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceDetailResponse;
 import com.genius.gitget.challenge.instance.dto.crud.InstancePagingResponse;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceUpdateRequest;
-import com.genius.gitget.challenge.instance.repository.InstanceRepository;
 import com.genius.gitget.challenge.instance.service.InstanceService;
-import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.util.exception.SuccessCode;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.PagingResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/admin/instance")
@@ -33,8 +33,8 @@ public class InstanceController {
 
     // 인스턴스 리스트 조회
     @GetMapping
-    public ResponseEntity<PagingResponse<InstancePagingResponse>> getAllInstances (
-            @PageableDefault(size = 5, direction = Sort.Direction.ASC, sort = "id") Pageable pageable) throws IOException{
+    public ResponseEntity<PagingResponse<InstancePagingResponse>> getAllInstances(
+            @PageableDefault(size = 5, direction = Sort.Direction.ASC, sort = "id") Pageable pageable) {
         Page<InstancePagingResponse> instances = instanceService.getAllInstances(pageable);
 
         return ResponseEntity.ok().body(
@@ -44,7 +44,7 @@ public class InstanceController {
 
     // 인스턴스 단건 조회
     @GetMapping("/{id}")
-    public ResponseEntity<SingleResponse<InstanceDetailResponse>> getInstanceById(@PathVariable Long id) throws IOException{
+    public ResponseEntity<SingleResponse<InstanceDetailResponse>> getInstanceById(@PathVariable Long id) {
         InstanceDetailResponse instanceDetails = instanceService.getInstanceById(id);
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SuccessCode.SUCCESS.getStatus(), SuccessCode.SUCCESS.getMessage(), instanceDetails)
@@ -55,7 +55,8 @@ public class InstanceController {
     @PostMapping
     public ResponseEntity<CommonResponse> createInstance(
             @RequestPart(value = "data") InstanceCreateRequest instanceCreateRequest,
-            @RequestPart(value = "files", required = false) MultipartFile multipartFile, @RequestPart(value = "type") String type) throws IOException {
+            @RequestPart(value = "files", required = false) MultipartFile multipartFile,
+            @RequestPart(value = "type") String type) {
         instanceService.createInstance(instanceCreateRequest, multipartFile, type);
         return ResponseEntity.ok().body(
                 new CommonResponse(SuccessCode.SUCCESS.getStatus(), SuccessCode.CREATED.getMessage())
@@ -64,8 +65,10 @@ public class InstanceController {
 
     // 인스턴스 수정
     @PatchMapping("/{id}")
-    public ResponseEntity<CommonResponse> updateInstance(@PathVariable Long id, @RequestPart(value = "data") InstanceUpdateRequest instanceUpdateRequest,
-                                                         @RequestPart(value = "files", required = false) MultipartFile multipartFile, @RequestPart(value = "type") String type) throws IOException{
+    public ResponseEntity<CommonResponse> updateInstance(@PathVariable Long id,
+                                                         @RequestPart(value = "data") InstanceUpdateRequest instanceUpdateRequest,
+                                                         @RequestPart(value = "files", required = false) MultipartFile multipartFile,
+                                                         @RequestPart(value = "type") String type) {
 
         instanceService.updateInstance(id, instanceUpdateRequest, multipartFile, type);
         return ResponseEntity.ok().body(
@@ -75,7 +78,7 @@ public class InstanceController {
 
     // 인스턴스 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<CommonResponse> deleteInstance(@PathVariable Long id) throws IOException{
+    public ResponseEntity<CommonResponse> deleteInstance(@PathVariable Long id) {
         instanceService.deleteInstance(id);
         return ResponseEntity.ok().body(
                 new CommonResponse(SuccessCode.SUCCESS.getStatus(), SuccessCode.SUCCESS.getMessage())

--- a/src/main/java/com/genius/gitget/challenge/instance/dto/crud/InstanceDetailResponse.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/dto/crud/InstanceDetailResponse.java
@@ -3,16 +3,16 @@ package com.genius.gitget.challenge.instance.dto.crud;
 import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.dto.FileResponse;
-import lombok.Builder;
-
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import lombok.Builder;
 
 @Builder
-public record InstanceDetailResponse(Long topicId, Long instanceId, String title, String description, int pointPerPerson,
-                                     String tags, String notice, LocalDateTime startedAt, LocalDateTime completedAt, FileResponse fileResponse) {
-    public static InstanceDetailResponse createByEntity(Instance instance, Optional<Files> files) throws IOException {
+public record InstanceDetailResponse(Long topicId, Long instanceId, String title, String description,
+                                     int pointPerPerson,
+                                     String tags, String notice, LocalDateTime startedAt, LocalDateTime completedAt,
+                                     FileResponse fileResponse) {
+    public static InstanceDetailResponse createByEntity(Instance instance, Optional<Files> files) {
         return InstanceDetailResponse.builder()
                 .topicId(instance.getTopic().getId())
                 .instanceId(instance.getId())
@@ -27,7 +27,7 @@ public record InstanceDetailResponse(Long topicId, Long instanceId, String title
                 .build();
     }
 
-    private static FileResponse convertToFileResponse(Optional<Files> files) throws IOException {
+    private static FileResponse convertToFileResponse(Optional<Files> files) {
         if (files.isEmpty()) {
             return FileResponse.createNotExistFile();
         }

--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceService.java
@@ -39,7 +39,7 @@ public class InstanceService {
         Topic topic = topicRepository.findById(instanceCreateRequest.topicId())
                 .orElseThrow(() -> new BusinessException(TOPIC_NOT_FOUND));
 
-        Files uploadedFile = filesService.uploadFile(multipartFile, type);
+        Files uploadedFile = filesService.uploadFile(topic.getFiles(), multipartFile, type);
 
         Instance instance = Instance.builder()
                 .title(instanceCreateRequest.title())

--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceService.java
@@ -1,31 +1,28 @@
 package com.genius.gitget.challenge.instance.service;
 
+import static com.genius.gitget.global.util.exception.ErrorCode.INSTANCE_NOT_FOUND;
+import static com.genius.gitget.global.util.exception.ErrorCode.TOPIC_NOT_FOUND;
+
+import com.genius.gitget.admin.topic.domain.Topic;
+import com.genius.gitget.admin.topic.repository.TopicRepository;
+import com.genius.gitget.challenge.instance.domain.Instance;
+import com.genius.gitget.challenge.instance.domain.Progress;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceCreateRequest;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceDetailResponse;
 import com.genius.gitget.challenge.instance.dto.crud.InstancePagingResponse;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceUpdateRequest;
-import com.genius.gitget.challenge.instance.domain.Progress;
-import com.genius.gitget.admin.topic.domain.Topic;
+import com.genius.gitget.challenge.instance.repository.InstanceRepository;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.service.FilesService;
 import com.genius.gitget.global.util.exception.BusinessException;
-import com.genius.gitget.challenge.instance.domain.Instance;
-import com.genius.gitget.challenge.instance.repository.InstanceRepository;
-import com.genius.gitget.admin.topic.repository.TopicRepository;
+import java.io.IOException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.Optional;
-
-import static com.genius.gitget.global.util.exception.ErrorCode.INSTANCE_NOT_FOUND;
-import static com.genius.gitget.global.util.exception.ErrorCode.TOPIC_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -38,7 +35,7 @@ public class InstanceService {
     // 인스턴스 생성
     @Transactional
     public Long createInstance(InstanceCreateRequest instanceCreateRequest,
-                                MultipartFile multipartFile, String type) throws IOException {
+                               MultipartFile multipartFile, String type) {
         Topic topic = topicRepository.findById(instanceCreateRequest.topicId())
                 .orElseThrow(() -> new BusinessException(TOPIC_NOT_FOUND));
 
@@ -70,7 +67,7 @@ public class InstanceService {
     }
 
     // 인스턴스 단건 조회
-    public InstanceDetailResponse getInstanceById(Long id) throws IOException {
+    public InstanceDetailResponse getInstanceById(Long id) {
         Instance instanceDetails = instanceRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(INSTANCE_NOT_FOUND));
         return InstanceDetailResponse.createByEntity(instanceDetails, instanceDetails.getFiles());
@@ -78,7 +75,7 @@ public class InstanceService {
 
     // 인스턴스 삭제
     @Transactional
-    public void deleteInstance(Long id) throws IOException{
+    public void deleteInstance(Long id) {
         Instance instance = instanceRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(INSTANCE_NOT_FOUND));
 
@@ -92,8 +89,8 @@ public class InstanceService {
 
     // 인스턴스 수정
     @Transactional
-    public Long updateInstance(Long id,  InstanceUpdateRequest instanceUpdateRequest,
-                               MultipartFile multipartFile, String type) throws IOException{
+    public Long updateInstance(Long id, InstanceUpdateRequest instanceUpdateRequest,
+                               MultipartFile multipartFile, String type) {
         Instance existingInstance = instanceRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(INSTANCE_NOT_FOUND));
 
@@ -101,7 +98,8 @@ public class InstanceService {
         Long findInstanceFileId = findInstanceFile.get().getId();
         filesService.updateFile(findInstanceFileId, multipartFile);
 
-        existingInstance.updateInstance(instanceUpdateRequest.description(), instanceUpdateRequest.notice(), instanceUpdateRequest.pointPerPerson(),
+        existingInstance.updateInstance(instanceUpdateRequest.description(), instanceUpdateRequest.notice(),
+                instanceUpdateRequest.pointPerPerson(),
                 instanceUpdateRequest.startedAt(), instanceUpdateRequest.completedAt());
 
         Instance savedInstance = instanceRepository.save(existingInstance);

--- a/src/main/java/com/genius/gitget/global/file/dto/FileResponse.java
+++ b/src/main/java/com/genius/gitget/global/file/dto/FileResponse.java
@@ -2,13 +2,12 @@ package com.genius.gitget.global.file.dto;
 
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.service.FileUtil;
-import java.io.IOException;
 
 public record FileResponse(
         Long fileId,
         String encodedFile) {
 
-    public static FileResponse createExistFile(Files files) throws IOException {
+    public static FileResponse createExistFile(Files files) {
         return new FileResponse(files.getId(), FileUtil.encodedImage(files));
     }
 

--- a/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
@@ -1,5 +1,6 @@
 package com.genius.gitget.global.file.service;
 
+import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_COPIED;
 import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_EXIST;
 import static com.genius.gitget.global.util.exception.ErrorCode.IMAGE_NOT_ENCODED;
 import static com.genius.gitget.global.util.exception.ErrorCode.NOT_SUPPORTED_EXTENSION;
@@ -9,8 +10,10 @@ import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.dto.UpdateDTO;
 import com.genius.gitget.global.file.dto.UploadDTO;
 import com.genius.gitget.global.util.exception.BusinessException;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.StandardCopyOption;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
@@ -54,6 +57,30 @@ public class FileUtil {
                 .savedFilename(savedFilename)
                 .fileURI(UPLOAD_PATH + fileType.getPath() + savedFilename)
                 .build();
+    }
+
+    public static UploadDTO getCopyInfo(Files files, FileType fileType, final String UPLOAD_PATH) {
+        String originalFilename = files.getOriginalFilename();
+        String savedFilename = getSavedFilename(originalFilename);
+
+        return UploadDTO.builder()
+                .fileType(fileType)
+                .originalFilename(originalFilename)
+                .savedFilename(savedFilename)
+                .fileURI(UPLOAD_PATH + fileType.getPath() + savedFilename)
+                .build();
+    }
+
+    public static void copyImage(String originFilePath, String copyFilePath) {
+        File originFile = new File(originFilePath);
+        File copyFile = new File(copyFilePath);
+
+        try {
+            java.nio.file.Files.copy(originFile.toPath(), copyFile.toPath(),
+                    StandardCopyOption.COPY_ATTRIBUTES);
+        } catch (IOException e) {
+            throw new BusinessException(FILE_NOT_COPIED);
+        }
     }
 
     public static void validateFile(MultipartFile file) {

--- a/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
@@ -1,6 +1,7 @@
 package com.genius.gitget.global.file.service;
 
 import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_EXIST;
+import static com.genius.gitget.global.util.exception.ErrorCode.IMAGE_NOT_ENCODED;
 import static com.genius.gitget.global.util.exception.ErrorCode.NOT_SUPPORTED_EXTENSION;
 
 import com.genius.gitget.global.file.domain.FileType;
@@ -20,11 +21,15 @@ import org.springframework.web.multipart.MultipartFile;
 public class FileUtil {
     private static final List<String> validExtensions = List.of("jpg", "jpeg", "png", "gif");
 
-    public static String encodedImage(Files files) throws IOException {
-        UrlResource urlResource = new UrlResource("file:" + files.getFileURI());
+    public static String encodedImage(Files files) {
+        try {
+            UrlResource urlResource = new UrlResource("file:" + files.getFileURI());
 
-        byte[] encode = Base64.getEncoder().encode(urlResource.getContentAsByteArray());
-        return new String(encode, StandardCharsets.UTF_8);
+            byte[] encode = Base64.getEncoder().encode(urlResource.getContentAsByteArray());
+            return new String(encode, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new BusinessException(IMAGE_NOT_ENCODED);
+        }
     }
 
     public static UploadDTO getUploadInfo(MultipartFile file, String typeStr, final String UPLOAD_PATH) {

--- a/src/main/java/com/genius/gitget/global/file/service/FilesService.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FilesService.java
@@ -2,6 +2,7 @@ package com.genius.gitget.global.file.service;
 
 import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_DELETED;
 import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_EXIST;
+import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_SAVED;
 
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.dto.FileResponse;
@@ -11,11 +12,9 @@ import com.genius.gitget.global.file.repository.FilesRepository;
 import com.genius.gitget.global.util.exception.BusinessException;
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,7 +32,7 @@ public class FilesService {
     }
 
     @Transactional
-    public Files uploadFile(MultipartFile receivedFile, String typeStr) throws IOException {
+    public Files uploadFile(MultipartFile receivedFile, String typeStr) {
         FileUtil.validateFile(receivedFile);
 
         UploadDTO uploadDTO = FileUtil.getUploadInfo(receivedFile, typeStr, UPLOAD_PATH);
@@ -50,17 +49,21 @@ public class FilesService {
         return filesRepository.save(file);
     }
 
-    private void saveFile(MultipartFile file, String fileURI) throws IOException {
-        File targetFile = new File(fileURI);
+    private void saveFile(MultipartFile file, String fileURI) {
+        try {
+            File targetFile = new File(fileURI);
 
-        if (!targetFile.exists()) {
-            targetFile.mkdirs();
+            if (!targetFile.exists()) {
+                targetFile.mkdirs();
+            }
+            file.transferTo(targetFile);
+        } catch (IOException e) {
+            throw new BusinessException(FILE_NOT_SAVED);
         }
-        file.transferTo(targetFile);
     }
 
     @Transactional
-    public Files updateFile(Long fileId, MultipartFile file) throws IOException {
+    public Files updateFile(Long fileId, MultipartFile file) {
         Files files = filesRepository.findById(fileId)
                 .orElseThrow(() -> new BusinessException(FILE_NOT_EXIST));
 
@@ -78,7 +81,7 @@ public class FilesService {
      * @param fileId 삭제하고자하는 Files 엔티티의 PK
      */
     @Transactional
-    public void deleteFile(Long fileId) throws IOException {
+    public void deleteFile(Long fileId) {
         Files files = filesRepository.findById(fileId)
                 .orElseThrow(() -> new BusinessException(FILE_NOT_EXIST));
 
@@ -94,19 +97,12 @@ public class FilesService {
         }
     }
 
-    public FileResponse getEncodedFile(Long fileId) throws IOException {
+    public FileResponse getEncodedFile(Long fileId) {
         Optional<Files> optionalFiles = filesRepository.findById(fileId);
         if (optionalFiles.isEmpty()) {
             return FileResponse.createNotExistFile();
         }
 
         return FileResponse.createExistFile(optionalFiles.get());
-    }
-
-    public UrlResource getFile(Long fileId) throws MalformedURLException {
-        Files files = filesRepository.findById(fileId)
-                .orElseThrow(() -> new BusinessException(FILE_NOT_EXIST));
-
-        return new UrlResource("file:" + files.getFileURI());
     }
 }

--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     FILE_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당 파일(이미지)이 존재하지 않습니다."),
     NOT_SUPPORTED_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 확장자입니다."),
     NOT_SUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 타입입니다."),
+    IMAGE_NOT_ENCODED(HttpStatus.BAD_REQUEST, "이미지를 인코딩하는 과정에서 오류가 발생했습니다."),
+    FILE_NOT_SAVED(HttpStatus.BAD_REQUEST, "파일(이미지)가 정상적으로 저장되지 않았습니다."),
     FILE_NOT_DELETED(HttpStatus.BAD_REQUEST, "파일(이미지)이 정상적으로 삭제되지 않았습니다.");
 
 

--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     NOT_SUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 타입입니다."),
     IMAGE_NOT_ENCODED(HttpStatus.BAD_REQUEST, "이미지를 인코딩하는 과정에서 오류가 발생했습니다."),
     FILE_NOT_SAVED(HttpStatus.BAD_REQUEST, "파일(이미지)가 정상적으로 저장되지 않았습니다."),
+    FILE_NOT_COPIED(HttpStatus.BAD_REQUEST, "파일(이미지)가 정상적으로 복사되지 않았습니다."),
     FILE_NOT_DELETED(HttpStatus.BAD_REQUEST, "파일(이미지)이 정상적으로 삭제되지 않았습니다.");
 
 

--- a/src/test/java/com/genius/gitget/global/file/service/FileUtilTest.java
+++ b/src/test/java/com/genius/gitget/global/file/service/FileUtilTest.java
@@ -1,11 +1,14 @@
 package com.genius.gitget.global.file.service;
 
+import static com.genius.gitget.global.file.domain.FileType.INSTANCE;
+import static com.genius.gitget.global.file.domain.FileType.TOPIC;
 import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_EXIST;
 import static com.genius.gitget.global.util.exception.ErrorCode.NOT_SUPPORTED_EXTENSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.genius.gitget.global.file.domain.FileType;
+import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.dto.UpdateDTO;
 import com.genius.gitget.global.file.dto.UploadDTO;
 import com.genius.gitget.global.util.exception.BusinessException;
@@ -91,6 +94,25 @@ class FileUtilTest {
         assertThat(updateDTO.originalFilename()).isEqualTo(originalFilename);
         assertThat(updateDTO.fileURI()).contains(UPLOAD_PATH);
         assertThat(updateDTO.fileURI()).contains(updateDTO.savedFilename());
+    }
+
+    @Test
+    @DisplayName("기존의 파일을 복사하려고 할 때, 복사에 필요한 정보들을 추출하여 전달할 수 있다.")
+    public void should_passInformation_when_tryToCopy() {
+        //given
+        Files files = Files.builder()
+                .originalFilename("original file name.png")
+                .savedFilename("saved file name")
+                .fileURI("file URI")
+                .fileType(TOPIC)
+                .build();
+
+        //when
+        UploadDTO copyInfo = FileUtil.getCopyInfo(files, INSTANCE, UPLOAD_PATH);
+
+        //then
+        assertThat(copyInfo.fileType()).isEqualTo(INSTANCE);
+        assertThat(copyInfo.fileURI()).contains(UPLOAD_PATH);
     }
 
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가

□ 기능 삭제

☑ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`hotfix/66-topic-delete-bug` → `main`

</br>

### 변경 사항
- [x] `TopicService`에서 topic을 delete한 후, `FilesService`를 통해 한 번 더 삭제하는 로직 제거
- [x]  `FilesService`와 `FilesUtil`에서 따로 처리하지 않았던 예외들에 대해 try-catch문을 통해 명시적으로 예외 처리
- [x] Topic에 등록된 이미지를 사용하기 위해, instance 생성 시 이미지를 별도로 전달하지 않은 경우에 대해 처리 로직 추가

</br>

### 테스트 결과

</br>

### 연관된 이슈
#66 

</br>

### 리뷰 요구사항(선택)
> Postman으로 직접 테스트 진행했을 때 정상작동 했으나, 혹시 제가 놓친 예외 부분이 있는지 한 번 확인 부탁드립니다!
