### PR TITLE
[BUG] 인스턴스 수정 시, 수정이 되지 않는 버그

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/dto/crud/InstancePagingResponse.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/dto/crud/InstancePagingResponse.java
@@ -3,15 +3,14 @@ package com.genius.gitget.challenge.instance.dto.crud;
 import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.dto.FileResponse;
-import lombok.Builder;
-
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import lombok.Builder;
 
 @Builder
-public record InstancePagingResponse (Long topicId, Long instanceId, String title,
-                                      LocalDateTime startedAt, LocalDateTime completedAt, FileResponse fileResponse) {
+public record InstancePagingResponse(Long topicId, Long instanceId, String title,
+                                     LocalDateTime startedAt, LocalDateTime completedAt, FileResponse fileResponse) {
     public static InstancePagingResponse createByEntity(Instance instance, Optional<Files> files) throws IOException {
         return InstancePagingResponse.builder()
                 .topicId(instance.getTopic().getId())
@@ -23,7 +22,7 @@ public record InstancePagingResponse (Long topicId, Long instanceId, String titl
                 .build();
     }
 
-    private static FileResponse convertToFileResponse(Optional<Files> files) throws IOException {
+    private static FileResponse convertToFileResponse(Optional<Files> files) {
         if (files.isEmpty()) {
             return FileResponse.createNotExistFile();
         }

--- a/src/main/java/com/genius/gitget/global/file/service/FilesService.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FilesService.java
@@ -75,6 +75,10 @@ public class FilesService {
         Files files = filesRepository.findById(fileId)
                 .orElseThrow(() -> new BusinessException(FILE_NOT_EXIST));
 
+        if (file == null) {
+            return files;
+        }
+
         deleteFilesInStorage(files);
 
         UpdateDTO updateDTO = FileUtil.getUpdateInfo(file, files.getFileType(), UPLOAD_PATH);


### PR DESCRIPTION
- 인스턴스 수정 API 요청 시, MultipartFile이 없을 때 처리하는 로직 보강

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가

□ 기능 삭제

☑ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`hotfix/71-instance-update-bug` → `main`

</br>

### 변경 사항
- [x] 인스턴스 수정 요청 시, 파일을 전달하지 않아도 예외가 나지 않게끔 처리 

</br>

### 테스트 결과


</br>

### 연관된 이슈
#71 

</br>

### 리뷰 요구사항(선택)
> 
