### PR TITLE
[BUG/FIX] 주간 인증 조회 API 기간 버그

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
@@ -58,7 +58,7 @@ public class CertificationService {
     public List<CertificationResponse> getWeekCertification(Long participantId, LocalDate currentDate) {
         LocalDate startDate = participantProvider.getInstanceStartDate(participantId);
         int curAttempt = DateUtil.getWeekAttempt(startDate, currentDate);
-        LocalDate weekStartDate = DateUtil.getWeekStartDate(currentDate);
+        LocalDate weekStartDate = DateUtil.getWeekStartDate(startDate, currentDate);
 
         List<Certification> certifications = certificationProvider.findByDuration(
                 weekStartDate,
@@ -79,12 +79,10 @@ public class CertificationService {
     private WeekResponse convertToWeekResponse(Participant participant, LocalDate currentDate) {
         User user = participant.getUser();
         LocalDate startDate = participantProvider.getInstanceStartDate(participant.getId());
-        LocalDate weekStartDate = DateUtil.getWeekStartDate(currentDate);
+        LocalDate weekStartDate = DateUtil.getWeekStartDate(startDate, currentDate);
 
         List<Certification> certifications = certificationProvider.findByDuration(
-                weekStartDate,
-                currentDate,
-                participant.getId());
+                weekStartDate, currentDate, participant.getId());
 
         List<CertificationResponse> certificationResponses = convertToCertificationResponse(
                 certifications,

--- a/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
@@ -23,14 +23,18 @@ public final class DateUtil {
         int weekAttempt = targetDate.getDayOfWeek().ordinal() + 1;
         int totalAttempt = getAttemptCount(challengeStartDate, targetDate);
 
-        if ((challengeStartDate.getDayOfWeek() != DayOfWeek.MONDAY) && (totalAttempt < 8)) {
+        if (isNotStartWithMonday(challengeStartDate, targetDate)) {
             return totalAttempt;
         }
 
         return weekAttempt;
     }
 
-    public static LocalDate getWeekStartDate(LocalDate currentDate) {
+    public static LocalDate getWeekStartDate(LocalDate challengeStartDate, LocalDate currentDate) {
+        if (isNotStartWithMonday(challengeStartDate, currentDate)) {
+            return challengeStartDate;
+        }
+
         return currentDate.minusDays(currentDate.getDayOfWeek().ordinal());
     }
 
@@ -39,6 +43,15 @@ public final class DateUtil {
                 date.toInstant(),
                 ZoneId.of("Asia/Seoul")
         );
+    }
+
+    private static boolean isNotStartWithMonday(LocalDate challengeStartDate, LocalDate currentDate) {
+        int totalAttempt = getAttemptCount(challengeStartDate, currentDate);
+        // 첫째주이고 && 시작일이 월요일이 아닐 때
+        if ((challengeStartDate.getDayOfWeek() != DayOfWeek.MONDAY) && (totalAttempt < 8)) {
+            return true;
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/105-week-certification-period-bug` → `main`

</br>

### 변경 사항
- [x] 인스턴스(챌린지)의 시작일자가 월요일이 아니고, 첫째주 주간 인증 현황 API를 요청하는 경우 해당 주의 첫째날(월요일)이 아닌 시작일자부터 기간이 시작해야 하는데, 월요일부터 시작하는 버그 발생
- [x] 첫째주이며 시작일자가 월요일이 아닌 경우, 시작일자를 반환하도록 하여 버그 픽스

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/6929ab79-13bc-41ff-9572-02010a12a7e1)


</br>

### 연관된 이슈
#105 

</br>

### 리뷰 요구사항(선택)
> 
