### PR TITLE
fix: 인증 패스 아이템 사용 시, 아이템 개수가 줄어들지 않았던 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
@@ -3,7 +3,6 @@ package com.genius.gitget.challenge.certification.service;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.CERTIFICATED;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.NOT_YET;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.PASSED;
-import static com.genius.gitget.global.util.exception.ErrorCode.CERTIFICATION_UNABLE;
 
 import com.genius.gitget.challenge.certification.domain.Certification;
 import com.genius.gitget.challenge.certification.dto.CertificationInformation;
@@ -152,6 +151,7 @@ public class CertificationService {
         UserItem userItem = userItemProvider.findUserItemByUser(userId, ItemCategory.CERTIFICATION_PASSER);
         Optional<Certification> optional = certificationProvider.findByDate(targetDate, participant.getId());
 
+        validCertificationCondition(instance, targetDate);
         validatePassCondition(userItem, optional);
 
         userItem.useItem();
@@ -210,11 +210,14 @@ public class CertificationService {
     }
 
     private void validCertificationCondition(Instance instance, LocalDate targetDate) {
+        if (instance.getProgress() != Progress.ACTIVITY) {
+            throw new BusinessException(ErrorCode.NOT_ACTIVITY_INSTANCE);
+        }
+
         boolean isValidPeriod = targetDate.isAfter(instance.getStartedDate().toLocalDate()) &&
                 targetDate.isBefore(instance.getCompletedDate().toLocalDate());
-
-        if ((instance.getProgress() != Progress.ACTIVITY) || !isValidPeriod) {
-            throw new BusinessException(CERTIFICATION_UNABLE);
+        if (!isValidPeriod) {
+            throw new BusinessException(ErrorCode.NOT_CERTIFICATE_PERIOD);
         }
     }
 

--- a/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
@@ -154,6 +154,8 @@ public class CertificationService {
 
         validatePassCondition(userItem, optional);
 
+        userItem.useItem();
+
         //TODO: 리팩토링 시급...
         if (optional.isPresent()) {
             Certification certification = optional.get();

--- a/src/main/java/com/genius/gitget/challenge/myChallenge/dto/RewardRequest.java
+++ b/src/main/java/com/genius/gitget/challenge/myChallenge/dto/RewardRequest.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 public record RewardRequest(
         User user,
         Long instanceId,
-        Boolean useItem,
+        Boolean canUseItem,
         LocalDate targetDate
 ) {
 }

--- a/src/main/java/com/genius/gitget/challenge/myChallenge/service/MyChallengeService.java
+++ b/src/main/java/com/genius/gitget/challenge/myChallenge/service/MyChallengeService.java
@@ -136,7 +136,7 @@ public class MyChallengeService {
         int pointPerPerson = instance.getPointPerPerson();
         int rewardPoints = pointPerPerson;
 
-        if (rewardRequest.useItem()) {
+        if (rewardRequest.canUseItem()) {
             UserItem userItem = userItemProvider.findUserItemByUser(user.getId(), ItemCategory.POINT_MULTIPLIER);
             userItem.useItem();
             rewardPoints = pointPerPerson * 2;

--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -54,7 +54,8 @@ public enum ErrorCode {
     CAN_NOT_JOIN_INSTANCE(HttpStatus.BAD_REQUEST, "해당 인스턴스에 참여할 수 없습니다."),
     CAN_NOT_QUIT_INSTANCE(HttpStatus.BAD_REQUEST, "해당 인스턴스의 참여를 취소할 수 없습니다."),
 
-    CERTIFICATION_UNABLE(HttpStatus.BAD_REQUEST, "해당 챌린지는 인증을 할 수 없는 상태입니다."),
+    NOT_ACTIVITY_INSTANCE(HttpStatus.BAD_REQUEST, "진행 중인 챌린지에 대해서만 인증이 가능합니다."),
+    NOT_CERTIFICATE_PERIOD(HttpStatus.BAD_REQUEST, "챌린지 인증은 챌린지 진행 기간 내에만 가능합니다. 챌린지 진행 기간인지 확인해주세요."),
 
     USER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 아이템 보유 정보를 찾을 수 없습니다."),
     HAS_NO_ITEM(HttpStatus.NOT_FOUND, "해당 아이템을 보유하고 있지 않습니다."),

--- a/src/test/java/com/genius/gitget/challenge/certification/service/CertificationServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/service/CertificationServiceTest.java
@@ -3,8 +3,8 @@ package com.genius.gitget.challenge.certification.service;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.CERTIFICATED;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.NOT_YET;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.PASSED;
-import static com.genius.gitget.global.util.exception.ErrorCode.CERTIFICATION_UNABLE;
 import static com.genius.gitget.global.util.exception.ErrorCode.GITHUB_TOKEN_NOT_FOUND;
+import static com.genius.gitget.global.util.exception.ErrorCode.NOT_CERTIFICATE_PERIOD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -136,7 +136,7 @@ class CertificationServiceTest {
         //when && then
         assertThatThrownBy(() -> certificationService.updateCertification(user, certificationRequest))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(CERTIFICATION_UNABLE.getMessage());
+                .hasMessageContaining(NOT_CERTIFICATE_PERIOD.getMessage());
     }
 
     @Test
@@ -402,6 +402,7 @@ class CertificationServiceTest {
                 .build();
 
         //when
+        instance.updateProgress(Progress.ACTIVITY);
         getSavedCertification(NOT_YET, currentDate, participant);
         getSavedCertification(CERTIFICATED, currentDate.plusDays(1), participant);
         getSavedCertification(CERTIFICATED, currentDate.plusDays(4), participant);
@@ -459,6 +460,8 @@ class CertificationServiceTest {
                 .targetDate(currentDate)
                 .build();
 
+        instance.updateProgress(Progress.ACTIVITY);
+
         //when && then
         assertThatThrownBy(() -> certificationService.passCertification(instance.getId(), certificationRequest))
                 .isInstanceOf(BusinessException.class)
@@ -481,6 +484,7 @@ class CertificationServiceTest {
                 .build();
 
         //when
+        instance.updateProgress(Progress.ACTIVITY);
         getSavedCertification(certificateStatus, currentDate, participant);
 
         //then
@@ -504,6 +508,7 @@ class CertificationServiceTest {
                 .build();
 
         //when
+        instance.updateProgress(Progress.ACTIVITY);
         getSavedCertification(NOT_YET, currentDate, participant);
         ActivatedResponse activatedResponse = certificationService.passCertification(user.getId(),
                 certificationRequest);
@@ -534,6 +539,7 @@ class CertificationServiceTest {
                 .build();
 
         //when
+        instance.updateProgress(Progress.ACTIVITY);
         ActivatedResponse activatedResponse = certificationService.passCertification(user.getId(),
                 certificationRequest);
 

--- a/src/test/java/com/genius/gitget/challenge/certification/service/CertificationServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/service/CertificationServiceTest.java
@@ -420,6 +420,7 @@ class CertificationServiceTest {
         assertThat(activatedResponse.numOfPassItem()).isEqualTo(0);
         assertThat(activatedResponse.canUsePassItem()).isFalse();
         assertThat(activatedResponse.fileResponse()).isNotNull();
+        assertThat(userItem.getCount()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/104-passer-item-bug` → `main`

</br>

### 변경 사항
아이템 사용 후, 사용자의 아이템 보유 정보를 가지고 있는 `UserItem`의 `count`를 줄이지 않아 나타나던 버그였습니다.
`CertificationService`의 `passCertification`에서 count를 줄이는 로직을 추가했습니다.

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/9f5dd999-758e-46aa-8022-cd1418c96441)


</br>

### 연관된 이슈
#104 


### 리뷰 요구사항(선택)

