### PR TITLE
[FEAT] 참여 정보 테이블에 '시작 전' 정보 추가

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
@@ -55,7 +55,6 @@ public class InstanceDetailService {
         instance.updateParticipantCount(1);
         Participant participant = Participant.createDefaultParticipant(repository);
         participant.setUserAndInstance(persistUser, instance);
-        participant.joinChallenge();
         return JoinResponse.createJoinResponse(participantProvider.save(participant));
     }
 

--- a/src/main/java/com/genius/gitget/challenge/instance/service/ProgressUpdater.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/ProgressUpdater.java
@@ -31,8 +31,15 @@ public class ProgressUpdater {
             LocalDate completedDate = preActivity.getCompletedDate().toLocalDate();
 
             if (currentDate.isAfter(startedDate) && currentDate.isBefore(completedDate)) {
-                preActivity.updateProgress(Progress.ACTIVITY);
+                updateActivityInstance(preActivity);
             }
+        }
+    }
+
+    private void updateActivityInstance(Instance preActivity) {
+        preActivity.updateProgress(Progress.ACTIVITY);
+        for (Participant participant : preActivity.getParticipantList()) {
+            participant.updateJoinResult(JoinResult.PROCESSING);
         }
     }
 
@@ -47,12 +54,12 @@ public class ProgressUpdater {
             LocalDate completedDate = instance.getCompletedDate().toLocalDate();
 
             if (currentDate.isAfter(startedDate) && currentDate.isAfter(completedDate)) {
-                updateParticipants(instance, currentDate);
+                updateDoneInstance(instance, currentDate);
             }
         }
     }
 
-    private void updateParticipants(Instance instance, LocalDate currentDate) {
+    private void updateDoneInstance(Instance instance, LocalDate currentDate) {
         instance.updateProgress(Progress.DONE);
         for (Participant participant : instance.getParticipantList()) {
             int totalAttempt = instance.getTotalAttempt();

--- a/src/main/java/com/genius/gitget/challenge/participant/domain/JoinResult.java
+++ b/src/main/java/com/genius/gitget/challenge/participant/domain/JoinResult.java
@@ -4,5 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum JoinResult {
-    FAIL, SUCCESS, PROCESSING
+    READY,
+    PROCESSING,
+    FAIL,
+    SUCCESS
 }

--- a/src/main/java/com/genius/gitget/challenge/participant/domain/Participant.java
+++ b/src/main/java/com/genius/gitget/challenge/participant/domain/Participant.java
@@ -65,28 +65,26 @@ public class Participant {
     private int rewardPoints;
 
     @Builder
-    private Participant(JoinStatus joinStatus, JoinResult joinResult, String repositoryName) {
+    private Participant(JoinStatus joinStatus, JoinResult joinResult, String repositoryName,
+                        RewardStatus rewardStatus, int rewardPoints) {
         this.joinStatus = joinStatus;
         this.joinResult = joinResult;
         this.repositoryName = repositoryName;
-        this.rewardStatus = RewardStatus.NO;
-        this.rewardPoints = 0;
+        this.rewardStatus = rewardStatus;
+        this.rewardPoints = rewardPoints;
     }
 
     public static Participant createDefaultParticipant(String repositoryName) {
         return Participant.builder()
                 .joinStatus(JoinStatus.YES)
-                .joinResult(JoinResult.PROCESSING)
+                .joinResult(JoinResult.READY)
                 .repositoryName(repositoryName)
+                .rewardStatus(RewardStatus.NO)
+                .rewardPoints(0)
                 .build();
     }
 
     //=== 비지니스 로직 ===//
-    public void joinChallenge() {
-        this.joinStatus = JoinStatus.YES;
-        this.joinResult = JoinResult.PROCESSING;
-    }
-
     public void quitChallenge() {
         this.joinStatus = JoinStatus.NO;
         this.joinResult = JoinResult.FAIL;

--- a/src/main/java/com/genius/gitget/challenge/participant/service/ParticipantProvider.java
+++ b/src/main/java/com/genius/gitget/challenge/participant/service/ParticipantProvider.java
@@ -1,6 +1,6 @@
 package com.genius.gitget.challenge.participant.service;
 
-import static com.genius.gitget.global.util.exception.ErrorCode.PARTICIPANT_INFO_NOT_FOUND;
+import static com.genius.gitget.global.util.exception.ErrorCode.PARTICIPANT_NOT_FOUND;
 
 import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.domain.Progress;
@@ -37,12 +37,12 @@ public class ParticipantProvider {
 
     public Participant findByJoinInfo(Long userId, Long instanceId) {
         return participantRepository.findByJoinInfo(userId, instanceId)
-                .orElseThrow(() -> new BusinessException(PARTICIPANT_INFO_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(PARTICIPANT_NOT_FOUND));
     }
 
     public Participant findById(Long participantInfoId) {
         return participantRepository.findById(participantInfoId)
-                .orElseThrow(() -> new BusinessException(PARTICIPANT_INFO_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(PARTICIPANT_NOT_FOUND));
     }
 
     public Slice<Participant> findAllByInstanceId(Long userId, Long instanceId, Pageable pageable) {
@@ -57,7 +57,7 @@ public class ParticipantProvider {
 
     public Instance getInstanceById(Long participantId) {
         return participantRepository.findById(participantId)
-                .orElseThrow(() -> new BusinessException(PARTICIPANT_INFO_NOT_FOUND))
+                .orElseThrow(() -> new BusinessException(PARTICIPANT_NOT_FOUND))
                 .getInstance();
     }
 

--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
 
     INVALID_INSTANCE_DATE(HttpStatus.BAD_REQUEST, "인스턴스 생성/종료 일자는 현재 일자 이후여야 합니다."),
     INSTANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인스턴스를 찾을 수 없습니다."),
-    PARTICIPANT_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 참여 정보를 찾을 수 없습니다."),
+    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 참여 정보를 찾을 수 없습니다."),
     CERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인증 정보를 찾을 수 없습니다."),
 
     ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 회원가입이 완료된 사용자입니다."),

--- a/src/test/java/com/genius/gitget/challenge/instance/service/InstanceDetailServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/instance/service/InstanceDetailServiceTest.java
@@ -3,7 +3,7 @@ package com.genius.gitget.challenge.instance.service;
 import static com.genius.gitget.global.util.exception.ErrorCode.CAN_NOT_JOIN_INSTANCE;
 import static com.genius.gitget.global.util.exception.ErrorCode.CAN_NOT_QUIT_INSTANCE;
 import static com.genius.gitget.global.util.exception.ErrorCode.INSTANCE_NOT_FOUND;
-import static com.genius.gitget.global.util.exception.ErrorCode.PARTICIPANT_INFO_NOT_FOUND;
+import static com.genius.gitget.global.util.exception.ErrorCode.PARTICIPANT_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -202,7 +202,7 @@ class InstanceDetailServiceTest {
         //when & then
         assertThatThrownBy(() -> instanceDetailService.quitChallenge(savedUser, savedInstance.getId()))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(PARTICIPANT_INFO_NOT_FOUND.getMessage());
+                .hasMessageContaining(PARTICIPANT_NOT_FOUND.getMessage());
     }
 
     @Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/102-add-participant-status` → `main`

</br>

### 변경 사항
> 사용자의 챌린지 참여 정보를 담는 `Participant` 테이블의 `JoinResult`에 시작 전을 나타내는 `READY`를 추가합니다.
> 그에 따라 비지니스 로직을 수정합니다.

#### 작업 상세 내용
- [x] `Participant` 테이블의 `JoinResult`에 `READY` 추가
- [x] 챌린지 참여 직후,  엔티티 생성 시 READY로 설정 후 저장
- [x] 챌린지 시작 이후, `READY` 에서 `PROCESSING`으로 변경
- [x] 관련 테스트 코드 수정 

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/1bf3295c-f8e7-4c9c-8892-a9e8b40ae3de)


</br>

### 연관된 이슈
#102 

</br>

### 리뷰 요구사항(선택)
> 
