### PR TITLE
[FEAT] JWT 요청 시, 사용자에 대한 정보 같이 전달

### DIFF
--- a/src/main/java/com/genius/gitget/global/security/controller/AuthController.java
+++ b/src/main/java/com/genius/gitget/global/security/controller/AuthController.java
@@ -5,9 +5,11 @@ import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.service.UserService;
 import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.global.security.dto.AuthResponse;
 import com.genius.gitget.global.security.dto.TokenDTO;
 import com.genius.gitget.global.security.service.JwtService;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
+import com.genius.gitget.global.util.response.dto.SingleResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,16 +29,17 @@ public class AuthController {
     private final JwtService jwtService;
 
     @PostMapping("/auth")
-    public ResponseEntity<CommonResponse> generateToken(HttpServletResponse response,
-                                                        @RequestBody TokenDTO tokenRequest) {
+    public ResponseEntity<SingleResponse<AuthResponse>> generateToken(HttpServletResponse response,
+                                                                      @RequestBody TokenDTO tokenRequest) {
         User requestUser = userService.findUserByIdentifier(tokenRequest.identifier());
         jwtService.validateUser(requestUser);
 
         jwtService.generateAccessToken(response, requestUser);
         jwtService.generateRefreshToken(response, requestUser);
+        AuthResponse authResponse = new AuthResponse(requestUser.getRole());
 
         return ResponseEntity.ok().body(
-                new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage())
+                new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), authResponse)
         );
     }
 

--- a/src/main/java/com/genius/gitget/global/security/dto/AuthResponse.java
+++ b/src/main/java/com/genius/gitget/global/security/dto/AuthResponse.java
@@ -1,0 +1,8 @@
+package com.genius.gitget.global.security.dto;
+
+import com.genius.gitget.challenge.user.domain.Role;
+
+public record AuthResponse(
+        Role role
+) {
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/113-add-user-data` → `main`

</br>

### 변경 사항
 `/auth` 를 통해 JWT 발급 API 요청에 대한 응답데이터에 사용자의 정보(ROLE)을 전달
JWT API의 응답 데이터에 사용자의 데이터(역할) 추가


</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/b66d564f-ceb4-4720-b4c6-2eb8ed752a32)


</br>

### 연관된 이슈
#113 

</br>

### 리뷰 요구사항(선택)
> 

