### PR TITLE
[FEAT] 챌린지 상세 페이지 응답 시 '좋아요'와 관련된 데이터 추가

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/domain/Instance.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/domain/Instance.java
@@ -129,6 +129,10 @@ public class Instance {
         this.progress = progress;
     }
 
+    public int getLikesCount() {
+        return this.likesList.size();
+    }
+
     public Optional<Files> getFiles() {
         return Optional.ofNullable(this.files);
     }

--- a/src/main/java/com/genius/gitget/challenge/instance/dto/detail/InstanceResponse.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/dto/detail/InstanceResponse.java
@@ -22,11 +22,11 @@ public record InstanceResponse(
         String notice,
         String certificationMethod,
         JoinStatus joinStatus,
-        int likesCount,
+        LikesInfo likesInfo,
         FileResponse fileResponse
 ) {
 
-    public static InstanceResponse createByEntity(Instance instance, JoinStatus joinStatus) {
+    public static InstanceResponse createByEntity(Instance instance, LikesInfo likesInfo, JoinStatus joinStatus) {
         LocalDate startedLocalDate = instance.getStartedDate().toLocalDate();
         LocalDate completedLocalDate = instance.getCompletedDate().toLocalDate();
         return InstanceResponse.builder()
@@ -42,7 +42,7 @@ public record InstanceResponse(
                 .notice(instance.getNotice())
                 .certificationMethod(instance.getCertificationMethod())
                 .joinStatus(joinStatus)
-                .likesCount(instance.getLikesList().size())
+                .likesInfo(likesInfo)
                 .fileResponse(FileResponse.create(instance.getFiles()))
                 .build();
     }

--- a/src/main/java/com/genius/gitget/challenge/instance/dto/detail/LikesInfo.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/dto/detail/LikesInfo.java
@@ -1,0 +1,27 @@
+package com.genius.gitget.challenge.instance.dto.detail;
+
+import lombok.Builder;
+
+@Builder
+public record LikesInfo(
+        Long likesId,
+        boolean isLiked,
+        int likesCount
+) {
+
+    public static LikesInfo createExist(Long likesId, int likesCount) {
+        return LikesInfo.builder()
+                .likesId(likesId)
+                .isLiked(true)
+                .likesCount(likesCount)
+                .build();
+    }
+
+    public static LikesInfo createNotExist() {
+        return LikesInfo.builder()
+                .likesId(0L)
+                .isLiked(false)
+                .likesCount(0)
+                .build();
+    }
+}

--- a/src/main/java/com/genius/gitget/challenge/likes/repository/LikesRepository.java
+++ b/src/main/java/com/genius/gitget/challenge/likes/repository/LikesRepository.java
@@ -1,7 +1,14 @@
 package com.genius.gitget.challenge.likes.repository;
 
 import com.genius.gitget.challenge.likes.domain.Likes;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+    @Query("select l from Likes l where l.user.id = :userId and l.instance.id = :instanceId")
+    Optional<Likes> findSpecificLike(@Param("userId") Long userId,
+                                     @Param("instanceId") Long instanceId);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/115-add-likes-instance-details` → `main`

</br>

### 변경 사항
- [x] 챌린지 상세 정보 조회 시, 좋아요 관련 정보(likesId, likesCount, isLiked)도 전달하도록 변경
- [x] Instance에 좋아요의 수를 반환하는 비니지스 로직 작성
- [x] 관련 테스트 코드 작성

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/d30856d4-1c80-4b32-8b3a-9e0f9a58c2d3)
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/18c46bd8-d484-4c8c-8227-1057268f1f45)


</br>

### 연관된 이슈
#115 

</br>

### 리뷰 요구사항(선택)
> 
