### PR TITLE
[FEAT] 회원가입 시 프로필 이미지를 받아 저장하는 기능

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/user/controller/UserController.java
+++ b/src/main/java/com/genius/gitget/challenge/user/controller/UserController.java
@@ -12,10 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,8 +33,10 @@ public class UserController {
     }
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<SingleResponse<TokenDTO>> signup(@RequestBody SignupRequest signupRequest) {
-        Long signupUserId = userService.signup(signupRequest);
+    public ResponseEntity<SingleResponse<TokenDTO>> signup(
+            @RequestPart(value = "data") SignupRequest signupRequest,
+            @RequestPart(value = "files") MultipartFile multipartFile) {
+        Long signupUserId = userService.signup(signupRequest, multipartFile);
         String identifier = userService.findUserById(signupUserId).getIdentifier();
 
         return ResponseEntity.ok().body(

--- a/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
+++ b/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
@@ -10,11 +10,14 @@ import com.genius.gitget.challenge.user.domain.Role;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.dto.SignupRequest;
 import com.genius.gitget.challenge.user.repository.UserRepository;
+import com.genius.gitget.global.file.domain.Files;
+import com.genius.gitget.global.file.service.FilesService;
 import com.genius.gitget.global.util.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
@@ -22,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final FilesService filesService;
     private final EncryptUtil encryptUtil;
 
 
@@ -41,17 +45,18 @@ public class UserService {
     }
 
     @Transactional
-    public Long signup(SignupRequest requestUser) {
+    public Long signup(SignupRequest requestUser, MultipartFile multipartFile) {
         User user = findUserByIdentifier(requestUser.identifier());
         isAlreadyRegistered(user);
 
-        //TODO: Converter 클래스 만들어서 적용하기
         String interest = String.join(",", requestUser.interest());
-
         user.updateUser(requestUser.nickname(),
                 requestUser.information(),
                 interest);
         user.updateRole(Role.USER);
+
+        Files files = filesService.uploadFile(multipartFile, "profile");
+        user.setFiles(files);
 
         return user.getId();
     }

--- a/src/test/java/com/genius/gitget/util/WithMockCustomUser.java
+++ b/src/test/java/com/genius/gitget/util/WithMockCustomUser.java
@@ -1,7 +1,7 @@
 package com.genius.gitget.util;
 
-import com.genius.gitget.global.security.constants.ProviderInfo;
 import com.genius.gitget.challenge.user.domain.Role;
+import com.genius.gitget.global.security.constants.ProviderInfo;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import org.springframework.security.test.context.support.WithSecurityContext;
@@ -21,4 +21,6 @@ public @interface WithMockCustomUser {
     String information() default "information";
 
     Role role() default Role.USER;
+
+    String profileName() default "profile";
 }

--- a/src/test/java/com/genius/gitget/util/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/genius/gitget/util/WithMockCustomUserSecurityContextFactory.java
@@ -6,6 +6,7 @@ import com.genius.gitget.challenge.user.dto.SignupRequest;
 import com.genius.gitget.challenge.user.repository.UserRepository;
 import com.genius.gitget.challenge.user.service.UserService;
 import com.genius.gitget.global.security.service.CustomUserDetailsService;
+import com.genius.gitget.util.file.FileTestUtil;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +50,8 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
                 .build();
 
         User savedUser = userRepository.save(user);
-        Long signupId = userService.signup(signupRequest);
+        Long signupId = userService.signup(signupRequest,
+                FileTestUtil.getMultipartFile(customUser.profileName()));
         savedUser.updateRole(customUser.role());
 
         UserDetails principal = customUserDetailsService.loadUserByUsername(String.valueOf(signupId));


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/123-save-profile-image` → `main`

</br>

### 변경 사항
- [x] 회원가입 API 요청 시, 프로필 사진을 저장하는 기능 추가 개발
- [x] 관련 테스트 코드 작성

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/c635ec17-6d63-4178-bc6e-b6f2599399e1)


</br>

### 연관된 이슈
#123 

</br>

### 리뷰 요구사항(선택)
> 요구사항은 아니고 참고사항입니다!
> 개발을 하다보니 FilesService에 개선사항이 보여서 이슈로 등록 후, 추후 수정할 예정입니다!
