### PR TITLE
[FIX] 인증 시스템 관련 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
@@ -93,7 +93,7 @@ public class CertificationController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long instanceId
     ) {
-        User user = userPrincipal.getUser();
+        User user = userService.findUserById(userPrincipal.getUser().getId());
         Participant participant = participantProvider.findByJoinInfo(user.getId(), instanceId);
         List<CertificationResponse> weekCertification = certificationService.getWeekCertification(
                 participant.getId(), LocalDate.now());

--- a/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
@@ -15,7 +15,6 @@ import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.domain.Progress;
 import com.genius.gitget.challenge.instance.service.InstanceProvider;
-import com.genius.gitget.store.item.service.OrdersProvider;
 import com.genius.gitget.challenge.myChallenge.dto.ActivatedResponse;
 import com.genius.gitget.challenge.participant.domain.Participant;
 import com.genius.gitget.challenge.participant.service.ParticipantProvider;
@@ -24,6 +23,7 @@ import com.genius.gitget.global.file.dto.FileResponse;
 import com.genius.gitget.global.file.service.FilesService;
 import com.genius.gitget.global.util.exception.BusinessException;
 import com.genius.gitget.global.util.exception.ErrorCode;
+import com.genius.gitget.store.item.service.OrdersProvider;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -189,7 +189,12 @@ public class CertificationService {
         );
 
         Certification certification = certificationProvider.findByDate(targetDate, participant.getId())
-                .map(updated -> certificationProvider.update(updated, targetDate, filteredPullRequests))
+                .map(updated -> {
+                    if (updated.getCertificationStatus() == PASSED) {
+                        throw new BusinessException(ErrorCode.ALREADY_PASSED_CERTIFICATION);
+                    }
+                    return certificationProvider.update(updated, targetDate, filteredPullRequests);
+                })
                 .orElseGet(
                         () -> certificationProvider.createCertification(participant, targetDate, filteredPullRequests)
                 );

--- a/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
@@ -1,6 +1,5 @@
 package com.genius.gitget.challenge.certification.util;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
@@ -23,7 +22,7 @@ public final class DateUtil {
         int weekAttempt = targetDate.getDayOfWeek().ordinal() + 1;
         int totalAttempt = getAttemptCount(challengeStartDate, targetDate);
 
-        if (isNotStartWithMonday(challengeStartDate, targetDate)) {
+        if (isFirstWeek(challengeStartDate, targetDate)) {
             return totalAttempt;
         }
 
@@ -31,11 +30,11 @@ public final class DateUtil {
     }
 
     public static LocalDate getWeekStartDate(LocalDate challengeStartDate, LocalDate currentDate) {
-        if (isNotStartWithMonday(challengeStartDate, currentDate)) {
+        if (isFirstWeek(challengeStartDate, currentDate)) {
             return challengeStartDate;
         }
-
-        return currentDate.minusDays(currentDate.getDayOfWeek().ordinal());
+        LocalDate mondayOfWeek = currentDate.minusDays(currentDate.getDayOfWeek().ordinal());
+        return mondayOfWeek;
     }
 
     public static LocalDate convertToLocalDate(Date date) {
@@ -45,10 +44,12 @@ public final class DateUtil {
         );
     }
 
-    private static boolean isNotStartWithMonday(LocalDate challengeStartDate, LocalDate currentDate) {
-        int totalAttempt = getAttemptCount(challengeStartDate, currentDate);
-        // 첫째주이고 && 시작일이 월요일이 아닐 때
-        if ((challengeStartDate.getDayOfWeek() != DayOfWeek.MONDAY) && (totalAttempt < 8)) {
+    private static boolean isFirstWeek(LocalDate challengeStartDate, LocalDate currentDate) {
+        LocalDate mondayOfWeek = challengeStartDate.minusDays(challengeStartDate.getDayOfWeek().ordinal());
+        LocalDate sundayOfWeek = mondayOfWeek.plusDays(6);
+        
+        if (currentDate.isAfter(mondayOfWeek.minusDays(1))
+                && currentDate.isBefore(sundayOfWeek.plusDays(1))) {
             return true;
         }
         return false;

--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
     INVALID_INSTANCE_DATE(HttpStatus.BAD_REQUEST, "인스턴스 생성/종료 일자는 현재 일자 이후여야 합니다."),
     INSTANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인스턴스를 찾을 수 없습니다."),
     PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 참여 정보를 찾을 수 없습니다."),
+
+    ALREADY_PASSED_CERTIFICATION(HttpStatus.BAD_REQUEST, "패스한 인증에 대해서는 인증 갱신할 수 없습니다."),
     CERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인증 정보를 찾을 수 없습니다."),
 
     ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 회원가입이 완료된 사용자입니다."),

--- a/src/test/java/com/genius/gitget/challenge/certification/service/CertificationServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/service/CertificationServiceTest.java
@@ -3,6 +3,7 @@ package com.genius.gitget.challenge.certification.service;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.CERTIFICATED;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.NOT_YET;
 import static com.genius.gitget.challenge.certification.domain.CertificateStatus.PASSED;
+import static com.genius.gitget.global.util.exception.ErrorCode.ALREADY_PASSED_CERTIFICATION;
 import static com.genius.gitget.global.util.exception.ErrorCode.GITHUB_TOKEN_NOT_FOUND;
 import static com.genius.gitget.global.util.exception.ErrorCode.NOT_CERTIFICATE_PERIOD;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,11 +22,6 @@ import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.domain.Progress;
 import com.genius.gitget.challenge.instance.repository.InstanceRepository;
-import com.genius.gitget.store.item.domain.Item;
-import com.genius.gitget.store.item.domain.ItemCategory;
-import com.genius.gitget.store.item.domain.Orders;
-import com.genius.gitget.store.item.repository.ItemRepository;
-import com.genius.gitget.store.item.repository.OrdersRepository;
 import com.genius.gitget.challenge.myChallenge.dto.ActivatedResponse;
 import com.genius.gitget.challenge.participant.domain.JoinResult;
 import com.genius.gitget.challenge.participant.domain.JoinStatus;
@@ -37,6 +33,11 @@ import com.genius.gitget.challenge.user.repository.UserRepository;
 import com.genius.gitget.global.security.constants.ProviderInfo;
 import com.genius.gitget.global.util.exception.BusinessException;
 import com.genius.gitget.global.util.exception.ErrorCode;
+import com.genius.gitget.store.item.domain.Item;
+import com.genius.gitget.store.item.domain.ItemCategory;
+import com.genius.gitget.store.item.domain.Orders;
+import com.genius.gitget.store.item.repository.ItemRepository;
+import com.genius.gitget.store.item.repository.OrdersRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -165,6 +166,32 @@ class CertificationServiceTest {
         assertThatThrownBy(() -> certificationService.updateCertification(user, certificationRequest))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(NOT_CERTIFICATE_PERIOD.getMessage());
+    }
+
+    @Test
+    @DisplayName("패스를 완료했을 때, 인증 갱신을 요청한다면 예외가 발생한다.")
+    public void should_throwException_when_passedAlready() {
+        //given
+        User user = getSavedUser(githubId);
+        Instance instance = getSavedInstance();
+        Participant participant = getSavedParticipant(user, instance);
+        githubService.registerGithubPersonalToken(user, personalKey);
+
+        LocalDate targetDate = LocalDate.of(2024, 2, 6);
+
+        CertificationRequest certificationRequest = CertificationRequest.builder()
+                .instanceId(instance.getId())
+                .targetDate(targetDate)
+                .build();
+        instance.updateProgress(Progress.ACTIVITY);
+
+        //when
+        getSavedCertification(PASSED, targetDate, participant);
+
+        //then
+        assertThatThrownBy(() -> certificationService.updateCertification(user, certificationRequest))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ALREADY_PASSED_CERTIFICATION.getMessage());
     }
 
     @Test

--- a/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
@@ -2,6 +2,7 @@ package com.genius.gitget.challenge.certification.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
@@ -92,5 +93,47 @@ class DateUtilTest {
 
         //then
         assertThat(remainDays).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("챌린지 시작 일자가 월요일이 아니고 시작한 그 주일 때, 시작일자를 반환해야 한다.")
+    public void should_returnStartDate_when_StartDateNotMonDayAndSecondWeek() {
+        LocalDate challengeStartDate = LocalDate.of(2024, 3, 13);
+        LocalDate targetDate = LocalDate.of(2024, 3, 15);
+
+        //when
+        LocalDate weekStartDate = DateUtil.getWeekStartDate(challengeStartDate, targetDate);
+
+        //then
+        assertThat(weekStartDate).isEqualTo(challengeStartDate);
+    }
+
+    @Test
+    @DisplayName("챌린지 시작일자가 월요일이 아니고 그 다움주일 때, 해당 주의 월요일을 반환해야 한다.")
+    public void should_returnMonday_when_startDateIsNotMonday() {
+        LocalDate challengeStartDate = LocalDate.of(2024, 3, 10);
+        LocalDate targetDate = LocalDate.of(2024, 3, 15);
+
+        //when
+        LocalDate weekStartDate = DateUtil.getWeekStartDate(challengeStartDate, targetDate);
+
+        //then
+
+        assertThat(weekStartDate.getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+    }
+
+    @Test
+    @DisplayName("챌린지 시작일자에 상관없이 시작한지 두 번째 주 일 때, 해당 주의 월요일을 전달해야한다")
+    public void should_returnMonday_when_secondWeek() {
+        //given
+        LocalDate challengeStartDate = LocalDate.of(2024, 3, 10);
+        LocalDate targetDate = LocalDate.of(2024, 3, 20);
+
+        //when
+        LocalDate weekStartDate = DateUtil.getWeekStartDate(challengeStartDate, targetDate);
+
+        //then
+        assertThat(weekStartDate).isEqualTo(LocalDate.of(2024, 3, 18));
+        assertThat(weekStartDate.getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/121-certification-bug-fix` → `main`

</br>

### 변경 사항
- [x] 챌린지의 시작일자가 일요일일 때, 첫째주 주간 인증 현황 조회 시 일요일까지 포함되어 반환되는 버그 픽스
- [x] '오늘의 인증 갱신' 기능에 예외 상황 추가 처리

</br>

### 테스트 결과
`UserControllerTest`에 실패 1건 존재. 수정 예정
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/7b6e0f1b-ef01-4c1b-a5a3-c63583ce3cc3)


</br>

### 연관된 이슈
#121 

</br>

### 리뷰 요구사항(선택)
> 
