### PR TITLE
[FEAT] 회원가입 시, 개발자에 해당하는 깃허브 계정인 경우 운영진으로 설정 

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/user/domain/User.java
+++ b/src/main/java/com/genius/gitget/challenge/user/domain/User.java
@@ -1,11 +1,11 @@
 package com.genius.gitget.challenge.user.domain;
 
-import com.genius.gitget.store.item.domain.Orders;
 import com.genius.gitget.challenge.likes.domain.Likes;
 import com.genius.gitget.challenge.participant.domain.Participant;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.security.constants.ProviderInfo;
 import com.genius.gitget.global.util.domain.BaseTimeEntity;
+import com.genius.gitget.store.item.domain.Orders;
 import com.genius.gitget.store.payment.domain.Payment;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;

--- a/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
+++ b/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
     private final FilesService filesService;
     private final EncryptUtil encryptUtil;
 
-    @Value("${githubId}")
+    @Value("${admin.githubId}")
     private List<String> adminIds;
 
 

--- a/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
+++ b/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
@@ -13,8 +13,10 @@ import com.genius.gitget.challenge.user.repository.UserRepository;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.service.FilesService;
 import com.genius.gitget.global.util.exception.BusinessException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,6 +29,9 @@ public class UserService {
     private final UserRepository userRepository;
     private final FilesService filesService;
     private final EncryptUtil encryptUtil;
+
+    @Value("${githubId}")
+    private List<String> adminIds;
 
 
     public User findUserById(Long id) {
@@ -53,12 +58,20 @@ public class UserService {
         user.updateUser(requestUser.nickname(),
                 requestUser.information(),
                 interest);
-        user.updateRole(Role.USER);
+        updateRole(user);
 
         Files files = filesService.uploadFile(multipartFile, "profile");
         user.setFiles(files);
 
         return user.getId();
+    }
+
+    private void updateRole(User user) {
+        if (adminIds.contains(user.getIdentifier())) {
+            user.updateRole(Role.ADMIN);
+            return;
+        }
+        user.updateRole(Role.USER);
     }
 
     public void isNicknameDuplicate(String nickname) {

--- a/src/test/java/com/genius/gitget/challenge/user/controller/UserControllerTest.java
+++ b/src/test/java/com/genius/gitget/challenge/user/controller/UserControllerTest.java
@@ -4,21 +4,29 @@ import static com.genius.gitget.global.util.exception.ErrorCode.DUPLICATED_NICKN
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.genius.gitget.challenge.user.domain.Role;
 import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.challenge.user.dto.SignupRequest;
 import com.genius.gitget.challenge.user.repository.UserRepository;
 import com.genius.gitget.global.security.constants.ProviderInfo;
+import com.genius.gitget.global.util.exception.BusinessException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,12 +35,17 @@ import org.springframework.web.context.WebApplicationContext;
 @SpringBootTest
 @Transactional
 @Slf4j
+@ActiveProfiles({"file"})
 class UserControllerTest {
     MockMvc mockMvc;
     @Autowired
     WebApplicationContext context;
     @Autowired
     UserRepository userRepository;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Value("${file.upload.path}")
+    private String testUploadPath;
 
     @BeforeEach
     public void setup() {
@@ -70,23 +83,31 @@ class UserControllerTest {
     @DisplayName("사용자의 회원가입이 완료되었다면 사용자의 identifier를 전달한다.")
     public void should_passIdentifier_when_signupCompleted() throws Exception {
         //given
-        saveUnsignedUser();
-
-        String requestBody = "{\"identifier\" : \"kimdozzi\",\"nickname\" : \"nickname\",\"interest\" : [\"Backend\", \"Frontend\"],\"information\" : \"hello\"}";
+        String identifier = "identifier";
+        saveUnsignedUser(identifier);
+        SignupRequest signupRequest = SignupRequest.builder()
+                .identifier(identifier)
+                .nickname("nickname")
+                .information("information")
+                .interest(List.of("관심사1", "관심사2"))
+                .build();
+        String signupAsString = objectMapper.writeValueAsString(signupRequest);
+        MockMultipartFile profileFile = setMockMultipartFile("testImage", "png");
 
         //when & then
-        mockMvc.perform(post("/api/auth/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().is2xxSuccessful());
+        mockMvc.perform(multipart("/api/auth/signup")
+                        .file(profileFile)
+                        .file(new MockMultipartFile("data", "", "application/json",
+                                signupAsString.getBytes(StandardCharsets.UTF_8))))
+                .andExpect(status().isOk());
     }
 
 
-    private void saveUnsignedUser() {
+    private void saveUnsignedUser(String identifier) {
         userRepository.save(User.builder()
                 .role(Role.NOT_REGISTERED)
                 .providerInfo(ProviderInfo.GITHUB)
-                .identifier("kimdozzi")
+                .identifier(identifier)
                 .build());
     }
 
@@ -99,5 +120,17 @@ class UserControllerTest {
                 .nickname("nickname")
                 .providerInfo(ProviderInfo.GITHUB)
                 .build());
+    }
+
+    private MockMultipartFile setMockMultipartFile(String fileName, String contentType) {
+        try {
+            return new MockMultipartFile("files",
+                    fileName + "." + contentType,
+//                    contentType,
+                    MediaType.IMAGE_PNG_VALUE,
+                    fileName.getBytes());
+        } catch (Exception e) {
+            throw new BusinessException(e);
+        }
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/127-signup-role` → `main`
 
</br>

### 변경 사항
> 회원가입 시, 개발자인 경우 자동으로 운영진으로 설정하는 기능을 추가합니다.

#### 작업 상세 내용
- [x] yml 파일에 개발자들의 GitHub ID 저장
- [x] 회원가입 요청 시, yml 파일을 통해 개발자 여부 확인 후 개발자가 맞다면 ADMIN으로 설정

</br>

### 테스트 결과
<img width="727" alt="image" src="https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/e71885b2-55f4-4c80-b7ea-ee4725a2daa1">


</br>

### 연관된 이슈
#127 

</br>

### 리뷰 요구사항(선택)
> 
