### PR TITLE
[FIX] 주간 인증 현황 조회 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/dto/CertificationResponse.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/dto/CertificationResponse.java
@@ -22,10 +22,10 @@ public record CertificationResponse(
 ) {
 
 
-    public static CertificationResponse createNonExist(int currentAttempt, LocalDate certificatedAt) {
+    public static CertificationResponse createNonExist(LocalDate certificatedAt) {
         return CertificationResponse.builder()
                 .certificationId(0L)
-                .certificationAttempt(currentAttempt)
+                .certificationAttempt(0)
                 .dayOfWeek(certificatedAt.getDayOfWeek())
                 .certificatedAt(certificatedAt)
                 .certificateStatus(NOT_YET)

--- a/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
@@ -138,7 +138,7 @@ public class CertificationService {
                 result.add(CertificationResponse.createExist(certificationMap.get(cur)));
                 continue;
             }
-            result.add(CertificationResponse.createNonExist(cur, startedDate));
+            result.add(CertificationResponse.createNonExist(startedDate));
         }
 
         return result;

--- a/src/main/java/com/genius/gitget/challenge/instance/domain/Instance.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/domain/Instance.java
@@ -175,6 +175,10 @@ public class Instance {
         return DateUtil.getAttemptCount(startedDate.toLocalDate(), completedDate.toLocalDate());
     }
 
+    public boolean isActivatedInstance() {
+        return this.progress == Progress.ACTIVITY;
+    }
+
     /*
      * 인스턴스 고유 uuid 설정
      * */

--- a/src/test/java/com/genius/gitget/challenge/certification/service/CertificationServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/service/CertificationServiceTest.java
@@ -258,9 +258,11 @@ class CertificationServiceTest {
         LocalDate currentDate = LocalDate.of(2024, 2, 3);
         LocalDate startDate = LocalDate.of(2024, 2, 1);
         LocalDate endDate = LocalDate.of(2024, 2, 4);
-        Participant participant = getSavedParticipant(getSavedUser(githubId), getSavedInstance());
+        Instance instance = getSavedInstance();
+        Participant participant = getSavedParticipant(getSavedUser(githubId), instance);
 
         //when
+        instance.updateProgress(Progress.ACTIVITY);
         getSavedCertification(NOT_YET, startDate, participant);
         getSavedCertification(CERTIFICATED, startDate.plusDays(1), participant);
         getSavedCertification(CERTIFICATED, endDate.minusDays(1), participant);
@@ -281,9 +283,11 @@ class CertificationServiceTest {
         LocalDate endDate = LocalDate.of(2024, 2, 29);
         LocalDate currentDate = LocalDate.of(2024, 2, 8);
 
-        Participant participant = getSavedParticipant(getSavedUser(githubId), getSavedInstance());
+        Instance instance = getSavedInstance();
+        Participant participant = getSavedParticipant(getSavedUser(githubId), instance);
 
         //when
+        instance.updateProgress(Progress.ACTIVITY);
         getSavedCertification(NOT_YET, startDate, participant);
         getSavedCertification(CERTIFICATED, startDate.plusDays(1), participant);
         getSavedCertification(CERTIFICATED, startDate.plusDays(4), participant);
@@ -294,10 +298,6 @@ class CertificationServiceTest {
 
         //then
         assertThat(weekCertification.size()).isEqualTo(4);
-        assertThat(weekCertification.get(0).certificationAttempt()).isEqualTo(1);
-        assertThat(weekCertification.get(1).certificationAttempt()).isEqualTo(2);
-        assertThat(weekCertification.get(2).certificationAttempt()).isEqualTo(3);
-        assertThat(weekCertification.get(3).certificationAttempt()).isEqualTo(4);
     }
 
     @Test
@@ -435,6 +435,7 @@ class CertificationServiceTest {
         Participant participant2 = getSavedParticipant(user2, instance);
 
         //when
+        instance.updateProgress(Progress.ACTIVITY);
         Slice<WeekResponse> certification = certificationService.getAllWeekCertification(
                 user1.getId(), instance.getId(), currentDate, pageRequest);
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가

□ 기능 삭제

□ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/136-certification-week-bug` → `main`

</br>

### 변경 사항
> 주간 인증 현황 조회 API와 관련된 버그를 픽스합니다

#### 작업 상세 내용
- [x] 패스를하고나서 이번주 인증 모아보기를 했을 때, 당일의 인증 내역이 제대로 보이지 않음. 데이터를 확인해보니 NOT_YET으로 전달됨
        확인 결과, 데이터 존재 여부 확인 로직에 문제가 있어 해당 로직 분리
- [x] 아직 시작하지 않은 챌린지/끝난 챌린지임에도 주간 인증 현황 조회 결과 반환 → 아무것도 전달하지 않아야 함
- [x] 관련 테스트 코드 변경

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/dc96d2e1-307a-4c9a-82de-7495836def0f)


</br>

### 연관된 이슈
#136 

</br>

### 리뷰 요구사항(선택)
> 
