### PR TITLE
[FIX] 전체 인증 조회 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/dto/CertificationResponse.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/dto/CertificationResponse.java
@@ -22,10 +22,10 @@ public record CertificationResponse(
 ) {
 
 
-    public static CertificationResponse createNonExist(LocalDate certificatedAt) {
+    public static CertificationResponse createNonExist(int certificationAttempt, LocalDate certificatedAt) {
         return CertificationResponse.builder()
                 .certificationId(0L)
-                .certificationAttempt(0)
+                .certificationAttempt(certificationAttempt)
                 .dayOfWeek(certificatedAt.getDayOfWeek())
                 .certificatedAt(certificatedAt)
                 .certificateStatus(NOT_YET)

--- a/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
@@ -109,9 +109,14 @@ public class CertificationService {
     public TotalResponse getTotalCertification(Long participantId, LocalDate currentDate) {
         Instance instance = participantProvider.getInstanceById(participantId);
         LocalDate startDate = instance.getStartedDate().toLocalDate();
-        int totalAttempts = instance.getTotalAttempt();
 
+        int totalAttempts = instance.getTotalAttempt();
         int curAttempt = DateUtil.getAttemptCount(startDate, currentDate);
+
+        if (instance.getProgress() == Progress.DONE) {
+            currentDate = instance.getCompletedDate().toLocalDate();
+            curAttempt = totalAttempts;
+        }
 
         List<Certification> certifications = certificationProvider.findByDuration(
                 startDate, currentDate, participantId);
@@ -138,7 +143,7 @@ public class CertificationService {
                 result.add(CertificationResponse.createExist(certificationMap.get(cur)));
                 continue;
             }
-            result.add(CertificationResponse.createNonExist(startedDate));
+            result.add(CertificationResponse.createNonExist(cur, startedDate));
         }
 
         return result;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가

□ 기능 삭제

☑ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/138-total-certification-bug` → `main`

</br>

### 변경 사항
- [x] 완료된 챌린지에 대해 전체 인증 내역 조회 시, 데이터의 개수가 잘못 전달되던 버그 픽스
- [x] 관련 테스트 코드 작성 


</br>

### 테스트 결과
`UserController`의 `Multipart` 관련 API 테스트에 오류 존재. 수정 예정
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/67afde02-d6b0-4dd3-9cd6-2c4b425f345c)



</br>

### 연관된 이슈
#138 

</br>

### 리뷰 요구사항(선택)
> 이후에 코드 리팩토링 예정입니다
