### PR TITLE
[FIX] 파일 저장 시, 특정 용량 이상의 파일이 전달되었을 때 발생하는 예외 추가 처리

### DIFF
--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     FILE_NOT_SAVED(HttpStatus.BAD_REQUEST, "파일(이미지)가 정상적으로 저장되지 않았습니다."),
     FILE_NOT_COPIED(HttpStatus.BAD_REQUEST, "파일(이미지)가 정상적으로 복사되지 않았습니다."),
     IMAGE_NOT_ENCODED(HttpStatus.BAD_REQUEST, "이미지를 인코딩하는 과정에서 오류가 발생했습니다."),
+    FILE_MAX_SIZE_EXCEED(HttpStatus.BAD_REQUEST, "파일(이미지)의 크기가 최대 용량을 초과했습니다."),
 
     GITHUB_CONNECTION_FAILED(HttpStatus.BAD_REQUEST, "Github 연결이 실패했습니다."),
     GITHUB_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 Github Token을 찾을 수 없습니다."),

--- a/src/main/java/com/genius/gitget/global/util/exception/FileExceptionHandler.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/FileExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.genius.gitget.global.util.exception;
+
+import static com.genius.gitget.global.util.exception.ErrorCode.FILE_MAX_SIZE_EXCEED;
+
+import com.genius.gitget.global.util.response.dto.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+@Slf4j
+@RestControllerAdvice
+public class FileExceptionHandler {
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<CommonResponse> globalExceptionHandler(Exception e) {
+        log.error("Multipart 용량이 최대 크기를 초과하여 예외가 발생했습니다.");
+        return ResponseEntity.badRequest().body(
+                new CommonResponse(HttpStatus.BAD_REQUEST, FILE_MAX_SIZE_EXCEED.getMessage()));
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/159-add-file-exception-handler` → `main`

</br>

### 변경 사항
- [x] 같은 이미지 저장 요청 시, 특정 용량 이상의 파일이 전달되었을 때 발생하는 `MaxUploadSizeExceededException` 예외를 핸들링하는 `FileExceptionHandler` 추가

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/d03220fc-152f-42cd-946d-6c03cbb2c0e6)


</br>

### 연관된 이슈
#159 

</br>

### 리뷰 요구사항(선택)
> 
