### PR TITLE
[FIX] 인스턴스 검색 결과에 인스턴스의 파일 정보가 넘어오지 않는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/dto/search/InstanceSearchResponse.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/dto/search/InstanceSearchResponse.java
@@ -1,5 +1,6 @@
 package com.genius.gitget.challenge.instance.dto.search;
 
+import com.genius.gitget.global.file.dto.FileResponse;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Data;
@@ -13,15 +14,17 @@ public class InstanceSearchResponse {
     private String keyword;
     private int pointPerPerson;
     private int participantCount;
+    private FileResponse fileResponse;
 
     @Builder
     @QueryProjection
     public InstanceSearchResponse(Long topicId, Long instanceId, String keyword, int pointPerPerson,
-                                  int participantCount) {
+                                  int participantCount, FileResponse fileResponse) {
         this.topicId = topicId;
         this.instanceId = instanceId;
         this.keyword = keyword;
         this.pointPerPerson = pointPerPerson;
         this.participantCount = participantCount;
+        this.fileResponse = fileResponse;
     }
 }

--- a/src/main/java/com/genius/gitget/challenge/instance/repository/SearchRepositoryCustom.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/repository/SearchRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.genius.gitget.challenge.instance.repository;
 
+import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.domain.Progress;
-import com.genius.gitget.challenge.instance.dto.search.InstanceSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface SearchRepositoryCustom {
-    Page<InstanceSearchResponse> search(Progress progress, String title, Pageable pageable);
+    Page<Instance> search(Progress progress, String title, Pageable pageable);
 }

--- a/src/main/java/com/genius/gitget/challenge/instance/repository/SearchRepositoryImpl.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/repository/SearchRepositoryImpl.java
@@ -2,9 +2,8 @@ package com.genius.gitget.challenge.instance.repository;
 
 import static com.genius.gitget.challenge.instance.domain.QInstance.instance;
 
+import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.domain.Progress;
-import com.genius.gitget.challenge.instance.dto.search.InstanceSearchResponse;
-import com.genius.gitget.challenge.instance.dto.search.QInstanceSearchResponse;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -23,7 +22,7 @@ public class SearchRepositoryImpl implements SearchRepositoryCustom {
     }
 
     @Override
-    public Page<InstanceSearchResponse> search(Progress progressCond, String titleCond, Pageable pageable) {
+    public Page<Instance> search(Progress progressCond, String titleCond, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
 
         if (progressCond != null) {
@@ -33,11 +32,8 @@ public class SearchRepositoryImpl implements SearchRepositoryCustom {
             builder.and(instance.title.contains(titleCond));
         }
 
-        List<InstanceSearchResponse> content = queryFactory
-                .select(new QInstanceSearchResponse(
-                        instance.topic.id, instance.id, instance.title, instance.pointPerPerson,
-                        instance.participantCount))
-                .from(instance)
+        List<Instance> content = queryFactory
+                .selectFrom(instance)
                 .where(builder)
                 .orderBy(instance.startedDate.desc())
                 .offset(pageable.getOffset())

--- a/src/test/java/com/genius/gitget/challenge/instance/repository/InstanceSearchRepositoryTest.java
+++ b/src/test/java/com/genius/gitget/challenge/instance/repository/InstanceSearchRepositoryTest.java
@@ -8,7 +8,6 @@ import com.genius.gitget.admin.topic.domain.Topic;
 import com.genius.gitget.admin.topic.repository.TopicRepository;
 import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceCreateRequest;
-import com.genius.gitget.challenge.instance.dto.search.InstanceSearchResponse;
 import com.genius.gitget.challenge.instance.service.InstanceSearchService;
 import com.genius.gitget.challenge.instance.service.InstanceService;
 import com.genius.gitget.util.file.FileTestUtil;
@@ -109,9 +108,9 @@ public class InstanceSearchRepositoryTest {
     public void 검색_조건_없이_테스트() throws Exception {
         for (int i = 0; i < 5; i++) {
             PageRequest pageRequest = PageRequest.of(i, 2);
-            Page<InstanceSearchResponse> result = searchRepository.search(null, null, pageRequest);
-            for (InstanceSearchResponse instanceSearchResponse : result) {
-                System.out.println("instanceSearchResponse = " + instanceSearchResponse.getInstanceId());
+            Page<Instance> result = searchRepository.search(null, null, pageRequest);
+            for (Instance instance : result) {
+                System.out.println("instanceSearchResponse = " + instance.getId());
             }
             System.out.println("========== " + i + 1 + " 번째 끝 =========");
         }
@@ -120,10 +119,10 @@ public class InstanceSearchRepositoryTest {
     @Test
     public void 챌린지_제목으로_검색_테스트() throws Exception {
         PageRequest pageRequest = PageRequest.of(0, 10);
-        Page<InstanceSearchResponse> result = searchRepository.search(null, "2", pageRequest);
+        Page<Instance> result = searchRepository.search(null, "2", pageRequest);
         int cnt = 0;
-        for (InstanceSearchResponse instanceSearchResponse : result) {
-            if (instanceSearchResponse != null) {
+        for (Instance instance : result) {
+            if (instance != null) {
                 cnt++;
             }
         }
@@ -134,10 +133,10 @@ public class InstanceSearchRepositoryTest {
     @Test
     public void 챌린지_현황으로_검색_테스트() throws Exception {
         PageRequest pageRequest = PageRequest.of(0, 10);
-        Page<InstanceSearchResponse> result = searchRepository.search(PREACTIVITY, null, pageRequest);
+        Page<Instance> result = searchRepository.search(PREACTIVITY, null, pageRequest);
         int cnt = 0;
-        for (InstanceSearchResponse instanceSearchResponse : result) {
-            if (instanceSearchResponse != null) {
+        for (Instance instance : result) {
+            if (instance != null) {
                 cnt++;
             }
         }
@@ -147,10 +146,10 @@ public class InstanceSearchRepositoryTest {
     @Test
     public void 챌린지_현황으로_검색_테스트2() throws Exception {
         PageRequest pageRequest = PageRequest.of(0, 10);
-        Page<InstanceSearchResponse> result = searchRepository.search(DONE, null, pageRequest);
+        Page<Instance> result = searchRepository.search(DONE, null, pageRequest);
         int cnt = 0;
-        for (InstanceSearchResponse instanceSearchResponse : result) {
-            if (instanceSearchResponse != null) {
+        for (Instance instance : result) {
+            if (instance != null) {
                 cnt++;
             }
         }
@@ -160,10 +159,10 @@ public class InstanceSearchRepositoryTest {
     @Test
     public void 챌린지_현황으로_검색_테스트3() throws Exception {
         PageRequest pageRequest = PageRequest.of(0, 10);
-        Page<InstanceSearchResponse> result = searchRepository.search(ACTIVITY, null, pageRequest);
+        Page<Instance> result = searchRepository.search(ACTIVITY, null, pageRequest);
         int cnt = 0;
-        for (InstanceSearchResponse instanceSearchResponse : result) {
-            if (instanceSearchResponse != null) {
+        for (Instance instance : result) {
+            if (instance != null) {
                 cnt++;
             }
         }
@@ -173,10 +172,10 @@ public class InstanceSearchRepositoryTest {
     @Test
     public void 챌린지_현황과_챌린지_제목으로_검색_테스트() throws Exception {
         PageRequest pageRequest = PageRequest.of(0, 10);
-        Page<InstanceSearchResponse> result = searchRepository.search(PREACTIVITY, "3", pageRequest);
+        Page<Instance> result = searchRepository.search(PREACTIVITY, "3", pageRequest);
         int cnt = 0;
-        for (InstanceSearchResponse instanceSearchResponse : result) {
-            if (instanceSearchResponse != null) {
+        for (Instance instance : result) {
+            if (instance != null) {
                 cnt++;
             }
         }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/167-search-not-contain-fileResponse` → `main`

</br>

### 변경 사항
> 인스턴스를 검색하는 API(`POST /api/challenges/search`) 에서 인스턴스의 파일 이미지가 전달되지 않는 버그를 픽스합니다.

- [x] `SearchRepositoryImpl`의 `search`의 응답으로 `instance`를 반환하도록 설정
- [x] `InstanceSearchService`의 `searchInstances`의 내부 로직에서 `FileResponse`를 생성하고 받도록 설정
- [x] 관련 테스트 코드 수정

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/3812ec7a-9513-4871-8da0-392c6d03046d)


</br>

### 연관된 이슈
#167

</br>

### 리뷰 요구사항(선택)
> 
