### PR TITLE
[REFACTOR] 파일이 저장소에 존재하지 않을 때에 대한 응답 데이터 리팩토링 및 추가 예외 처리

### DIFF
--- a/src/main/java/com/genius/gitget/global/file/dto/FileResponse.java
+++ b/src/main/java/com/genius/gitget/global/file/dto/FileResponse.java
@@ -9,6 +9,6 @@ public record FileResponse(
     }
 
     public static FileResponse createNotExistFile() {
-        return new FileResponse(0L, "none");
+        return new FileResponse(0L, "");
     }
 }

--- a/src/main/java/com/genius/gitget/global/file/service/FileManager.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FileManager.java
@@ -17,7 +17,8 @@ public interface FileManager {
      * Files 내에 저장된 값들을 통해 UrlResource 등으로 다운받은 후, base64로 인코딩한 결과 반환
      *
      * @param files 얻기 원하는 파일의 정보를 담고 있는 Files 객체
-     * @return base64로 encode한 결과 값(문자열)
+     * @return base64로 encode한 결과 값(문자열) 반환
+     * 파일을 받아오지 못한 경우에는 빈 문자열("") 반환
      */
     String getEncodedImage(Files files);
 

--- a/src/main/java/com/genius/gitget/global/file/service/FileManager.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FileManager.java
@@ -33,10 +33,12 @@ public interface FileManager {
 
     /**
      * 기존에 저장소에 저장되어 있던 파일을 특정 타입에 복사 후, Files 객체 생성에 필요한 정보들을 반환
+     * NOTE!! 복사 이전에 원본이 되는 파일이 저장소에 존재하는지 `validateFileExist()`를 통해 확인 필요
      *
      * @param files    복사하고자하는 파일의 정보를 담고 있는 Files 객체
      * @param fileType 복사해서 적용하고 싶은 대상의 파일 타입(TOPIC/INSTANCE/PROFILE 중 택 1)
      * @return Files 객체 생성에 필요한 정보(UploadDTO) 반환
+     * @throws BusinessException 원본이 되는 파일이 저장소에 존재하지 않는 경우 FILE_NOT_EXIST 발생
      */
     FileDTO copy(Files files, FileType fileType);
 
@@ -56,4 +58,14 @@ public interface FileManager {
      * @throws BusinessException 삭제에 실패했을 때 발생
      */
     void deleteInStorage(Files files);
+
+    /**
+     * Files 객체 내의 정보를 활용하여 저장소에 파일이 저장이 되어 있는지 확인 후 boolean 반환
+     * 각 저장소의 특성에 맞춰 Files 내의 메타데이터를 통해 저장소 내에 파일이 제대로 저장되어 있는지 확인
+     * 파일이 존재하지 않는 경우 FILE_NOT_EXIST 예외 발생 시킬 것
+     *
+     * @param files 저장소에 저장되어 있는지 확인하고자하는 Files 객체
+     * @throws FILE_NOT_EXIST 저장소에서 파일(이미지)을 찾을 수 없을 때 발생
+     */
+    void validateFileExist(Files files);
 }

--- a/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FileUtil.java
@@ -1,6 +1,6 @@
 package com.genius.gitget.global.file.service;
 
-import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_EXIST;
+import static com.genius.gitget.global.util.exception.ErrorCode.INVALID_FILE_NAME;
 import static com.genius.gitget.global.util.exception.ErrorCode.NOT_SUPPORTED_EXTENSION;
 
 import com.genius.gitget.global.file.domain.FileType;
@@ -48,7 +48,7 @@ public class FileUtil {
         String originalFilename = file.getOriginalFilename();
 
         if (originalFilename == null || Objects.equals(originalFilename, "")) {
-            throw new BusinessException(FILE_NOT_EXIST);
+            throw new BusinessException(INVALID_FILE_NAME);
         }
 
         String extension = extractExtension(originalFilename);

--- a/src/main/java/com/genius/gitget/global/file/service/LocalFileManager.java
+++ b/src/main/java/com/genius/gitget/global/file/service/LocalFileManager.java
@@ -52,7 +52,8 @@ public class LocalFileManager implements FileManager {
             byte[] encode = Base64.getEncoder().encode(urlResource.getContentAsByteArray());
             return new String(encode, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            throw new BusinessException(e);
+            //TODO: 불러오는 중의 예외에 대해 Logging 추가하기
+            return "";
         }
     }
 

--- a/src/main/java/com/genius/gitget/global/file/service/LocalFileManager.java
+++ b/src/main/java/com/genius/gitget/global/file/service/LocalFileManager.java
@@ -2,6 +2,7 @@ package com.genius.gitget.global.file.service;
 
 import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_COPIED;
 import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_DELETED;
+import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_EXIST;
 import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_SAVED;
 
 import com.genius.gitget.global.file.domain.FileType;
@@ -59,6 +60,8 @@ public class LocalFileManager implements FileManager {
 
     @Override
     public FileDTO copy(Files files, FileType fileType) {
+        validateFileExist(files);
+
         CopyDTO copyDTO = fileUtil.getCopyInfo(files, fileType, UPLOAD_PATH);
         createPath(copyDTO.folderURI());
 
@@ -93,6 +96,15 @@ public class LocalFileManager implements FileManager {
         File targetFile = new File(fileURI);
         if (!targetFile.delete()) {
             throw new BusinessException(FILE_NOT_DELETED);
+        }
+    }
+
+    @Override
+    public void validateFileExist(Files files) {
+        String fileURI = files.getFileURI();
+        File file = new File(fileURI);
+        if (!file.exists()) {
+            throw new BusinessException(FILE_NOT_EXIST);
         }
     }
 

--- a/src/main/java/com/genius/gitget/global/file/service/S3FileManager.java
+++ b/src/main/java/com/genius/gitget/global/file/service/S3FileManager.java
@@ -34,7 +34,8 @@ public class S3FileManager implements FileManager {
             byte[] encode = Base64.getEncoder().encode(urlResource.getContentAsByteArray());
             return new String(encode, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            throw new BusinessException(e);
+            //TODO: 불러오는 중의 예외에 대해 Logging 추가하기
+            return "";
         }
     }
 

--- a/src/main/java/com/genius/gitget/global/file/service/S3FileManager.java
+++ b/src/main/java/com/genius/gitget/global/file/service/S3FileManager.java
@@ -1,5 +1,7 @@
 package com.genius.gitget.global.file.service;
 
+import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_EXIST;
+
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
@@ -58,6 +60,8 @@ public class S3FileManager implements FileManager {
 
     @Override
     public FileDTO copy(Files files, FileType fileType) {
+        validateFileExist(files);
+        
         CopyDTO copyDTO = fileUtil.getCopyInfo(files, fileType, "");
 
         CopyObjectRequest copyObjectRequest = new CopyObjectRequest(
@@ -87,6 +91,13 @@ public class S3FileManager implements FileManager {
             amazonS3.deleteObject(bucket, files.getFileURI());
         } catch (SdkClientException e) {
             throw new BusinessException(e);
+        }
+    }
+
+    @Override
+    public void validateFileExist(Files files) {
+        if (!amazonS3.doesObjectExist(bucket, files.getFileURI())) {
+            throw new BusinessException(FILE_NOT_EXIST);
         }
     }
 }

--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
     TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 토픽을 찾을 수 없습니다."),
     TOPIC_HAVE_INSTANCE(HttpStatus.BAD_REQUEST, "해당 토픽은 인스턴스를 가지고 있으므로 삭제할 수 없습니다."),
+    TOPIC_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "토픽 이미지가 존재하지 않습니다. 토픽 이미지를 설정해주세요."),
 
     INVALID_INSTANCE_DATE(HttpStatus.BAD_REQUEST, "인스턴스 생성/종료 일자는 현재 일자 이후여야 합니다."),
     INSTANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인스턴스를 찾을 수 없습니다."),

--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
 
     MULTIPART_FILE_NOT_EXIST(HttpStatus.BAD_REQUEST, "MultipartFile이 전달되지 않았습니다."),
     FILE_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당 파일(이미지)이 존재하지 않습니다."),
+    INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "전달받은 파일(이미지)의 이름이 null이거나 빈 문자열입니다."),
     NOT_SUPPORTED_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 확장자입니다."),
     NOT_SUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 타입입니다."),
     FILE_NOT_DELETED(HttpStatus.BAD_REQUEST, "파일(이미지)이 정상적으로 삭제되지 않았습니다."),

--- a/src/test/java/com/genius/gitget/global/file/service/FileUtilTest.java
+++ b/src/test/java/com/genius/gitget/global/file/service/FileUtilTest.java
@@ -2,7 +2,7 @@ package com.genius.gitget.global.file.service;
 
 import static com.genius.gitget.global.file.domain.FileType.INSTANCE;
 import static com.genius.gitget.global.file.domain.FileType.TOPIC;
-import static com.genius.gitget.global.util.exception.ErrorCode.FILE_NOT_EXIST;
+import static com.genius.gitget.global.util.exception.ErrorCode.INVALID_FILE_NAME;
 import static com.genius.gitget.global.util.exception.ErrorCode.NOT_SUPPORTED_EXTENSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -46,7 +46,7 @@ class FileUtilTest {
         //when&then
         assertThatThrownBy(() -> fileUtil.validateFile(multipartFile))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(FILE_NOT_EXIST.getMessage());
+                .hasMessageContaining(INVALID_FILE_NAME.getMessage());
     }
 
     @Test
@@ -58,7 +58,7 @@ class FileUtilTest {
         //when&then
         assertThatThrownBy(() -> fileUtil.validateFile(multipartFile))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(FILE_NOT_EXIST.getMessage());
+                .hasMessageContaining(INVALID_FILE_NAME.getMessage());
     }
 
     @Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`refactor/178-change-file-response` → `main`

</br>


### 변경 사항
- [x] `FileResponse`의 `createNotExistFile()`을 호출했을 때, `encodedFile`의 값으로 빈 문자열("")을 반환하도록 변경
- [x] `FileManager`의 `getEncodedImage()` 메서드에서 파일을 받아오지 못한 경우 빈 문자열("") 반환하도록 변경
- [x] Topic 목록 조회/단일 조회, Instance 목록 조회/단일 조회, Profile 조회 경우에 대해 200번대 응답 코드 전송 및 빈 문자열 반환 확인
- [x] `FileManager`에 `validateFileExist()` 메서드를 추가하여, `copy()` 메서드 호출 이전에 `validateFileExist()`를 호출하여 원본 파일이 존재하는지 확인 
          만일, 원본 파일이 존재하지 않는 경우에는 `FILE_NOT_EXIST` 예외를 발생하도록 처리
    - [x] 특정 Topic을 통해 Instance를 생성할 때
        - [x] Topic의 이미지가 없는 경우 && Instance 생성 시 이미지를 전달 O → 정상 작동 확인
        - [x] Topic의 이미지가 없는 경우 && Instance 생성 시 이미지를 전달 X 
        → 생성 API가 분리되어 있어, 인스턴스를 생성되고 파일은 저장되지 않는 문제점 발견 && 프론트측에 추가 처리 요청 완료

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/75217e8b-975e-4a68-b312-e6ce560f5c61)


</br>

### 연관된 이슈
#178 #179 

</br>

### 리뷰 요구사항(선택)
> 
