### PR TITLE
[FIX] 추천 챌린지가 제대로 전달되지 않는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/repository/InstanceRepository.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/repository/InstanceRepository.java
@@ -18,8 +18,8 @@ public interface InstanceRepository extends JpaRepository<Instance, Long> {
     @Query("select i from Instance i where i.topic.id = :topicId")
     Page<Instance> findInstancesByTopicId(Pageable pageable, Long topicId);
 
-    @Query("select i from Instance i where i.progress = :progress and i.tags in :userTags")
-    Slice<Instance> findRecommendations(@Param("userTags") List<String> userTags, Progress progress, Pageable pageable);
+    @Query("select i from Instance i where i.progress = :progress and i.tags like %:userTag%")
+    List<Instance> findRecommendations(@Param("userTag") String userTag, Progress progress);
 
     @Query("select i from Instance i where i.progress = :progress")
     Slice<Instance> findPagesByProgress(@Param("progress") Progress progress, Pageable pageable);

--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceHomeService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceHomeService.java
@@ -8,10 +8,12 @@ import com.genius.gitget.challenge.instance.repository.InstanceRepository;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.global.file.dto.FileResponse;
 import com.genius.gitget.global.file.service.FilesService;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -26,12 +28,20 @@ public class InstanceHomeService {
     private final InstanceRepository instanceRepository;
 
     public Slice<HomeInstanceResponse> getRecommendations(User user, Pageable pageable) {
+        List<Instance> instances = new ArrayList<>();
         List<String> userTags = Arrays.stream(user.getTags().split(",")).toList();
+        for (String userTag : userTags) {
+            instances.addAll(instanceRepository.findRecommendations(userTag, PREACTIVITY));
+        }
 
-        Slice<Instance> recommendations = instanceRepository.findRecommendations(userTags, PREACTIVITY,
-                pageable);
+        List<HomeInstanceResponse> recommendations = instances.stream()
+                .distinct()
+                .map(this::mapToHomeInstanceResponse)
+                .toList();
 
-        return recommendations.map(this::mapToHomeInstanceResponse);
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), recommendations.size());
+        return new PageImpl<>(recommendations.subList(start, end), pageable, recommendations.size());
     }
 
     public Slice<HomeInstanceResponse> getInstancesByCondition(Pageable pageable) {

--- a/src/test/java/com/genius/gitget/challenge/instance/repository/InstanceRepositoryTest.java
+++ b/src/test/java/com/genius/gitget/challenge/instance/repository/InstanceRepositoryTest.java
@@ -158,32 +158,26 @@ class InstanceRepositoryTest {
 
 
     @Test
-    @DisplayName("인스턴스들 중, 사용자의 tag가 포함되어 있는 인스턴스들을 반환받을 수 있다.")
+    @DisplayName("인스턴스들 중, 사용자의 태그와 하나라도 겹친다면 추천 챌린지 결과로 반환받아야 한다.")
     public void should_returnInstances_containsUserTags() {
         //given
-        List<String> userTags = List.of("BE", "FE", "AI");
-        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Direction.DESC, "participantCount"));
+        String userTag = "BE";
 
         //when
-        getSavedInstance("title1", "BE", 10);
-        getSavedInstance("title2", "FE", 3);
+        getSavedInstance("title1", "BE,AI", 10);
+        getSavedInstance("title2", "FE,BE", 3);
         getSavedInstance("title3", "FE", 20);
-        Slice<Instance> suggestions = instanceRepository.findRecommendations(userTags, Progress.PREACTIVITY,
-                pageRequest);
+        List<Instance> recommendations = instanceRepository.findRecommendations(userTag, Progress.PREACTIVITY);
 
         //then
-        assertThat(suggestions.getContent().size()).isEqualTo(3);
-        assertThat(suggestions.getContent().get(0).getTitle()).isEqualTo("title3");
-        assertThat(suggestions.getContent().get(0).getTags()).isEqualTo("FE");
-        assertThat(suggestions.getContent().get(0).getParticipantCount()).isEqualTo(20);
+        assertThat(recommendations.size()).isEqualTo(2);
+        assertThat(recommendations.get(0).getTitle()).isEqualTo("title1");
+        assertThat(recommendations.get(0).getTags()).isEqualTo("BE,AI");
+        assertThat(recommendations.get(0).getParticipantCount()).isEqualTo(10);
 
-        assertThat(suggestions.getContent().get(1).getTitle()).isEqualTo("title1");
-        assertThat(suggestions.getContent().get(1).getTags()).isEqualTo("BE");
-        assertThat(suggestions.getContent().get(1).getParticipantCount()).isEqualTo(10);
-
-        assertThat(suggestions.getContent().get(2).getTitle()).isEqualTo("title2");
-        assertThat(suggestions.getContent().get(2).getTags()).isEqualTo("FE");
-        assertThat(suggestions.getContent().get(2).getParticipantCount()).isEqualTo(3);
+        assertThat(recommendations.get(1).getTitle()).isEqualTo("title2");
+        assertThat(recommendations.get(1).getTags()).isEqualTo("FE,BE");
+        assertThat(recommendations.get(1).getParticipantCount()).isEqualTo(3);
     }
 
     @Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/180-recommend-bug-fix` → `main`

</br>

### 변경 사항
> 홈화면에서 추천 챌린지가 제대로 전달되지 않는 버그 픽스
> 
> 🔥 버그 원인
> 사용자의 관심 태그의 개수 <= 인스턴스 관심 태그의 개수 일 때 문제 발생
> 사용자의 관심 태그를 split해서 List<String>으로 전달하는데, `i.tags in :userTags` 쿼리문에서 문제가 발생 (in절은 일치해야하기 때문)

#### 작업 상세 내용
- [x] 인스턴스의 태그의 개수 >= 사용자의 태그의 개수일 때, 추천 인스턴스가 제대로 뜨지 않는 버그 픽스
    - [x] 쿼리문을 in에서 like문으로 수정
    - [x] 쿼리문에 사용자 태그 전달 시, for-each문을 통해 하나씩 전달 후 통합
- [x] 관련 테스트 코드 작성
    - [x] 인스턴스가 여러 개의 태그를 가지고 있을 때, 제대로 반환하는지 확인
    - [x] 반환하는 데이터의 개수가 pageSize보다 적을 때/많을 때 페이징이 제대로 작동하는지 확인


</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/244027bf-7765-4054-bfd9-ff447537c6e7)


</br>

### 연관된 이슈
#180

</br>

### 리뷰 요구사항(선택)
> 
