### PR TITLE
[FIX] FE에서 Item을 식별하는 코드가 제대로 설정되지 않는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/store/item/controller/ItemController.java
+++ b/src/main/java/com/genius/gitget/store/item/controller/ItemController.java
@@ -6,10 +6,12 @@ import com.genius.gitget.global.security.domain.UserPrincipal;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.ListResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
+import com.genius.gitget.store.item.domain.Item;
 import com.genius.gitget.store.item.domain.ItemCategory;
 import com.genius.gitget.store.item.dto.ItemResponse;
 import com.genius.gitget.store.item.dto.ItemUseResponse;
 import com.genius.gitget.store.item.dto.ProfileResponse;
+import com.genius.gitget.store.item.service.ItemProvider;
 import com.genius.gitget.store.item.service.ItemService;
 import java.time.LocalDate;
 import java.util.List;
@@ -28,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class ItemController {
     private final ItemService itemService;
+    private final ItemProvider itemProvider;
 
     @GetMapping("/items")
     public ResponseEntity<ListResponse<ItemResponse>> getItemList(
@@ -47,26 +50,28 @@ public class ItemController {
         );
     }
 
-    @PostMapping("/items/order/{itemId}")
+    @PostMapping("/items/order/{identifier}")
     public ResponseEntity<SingleResponse<ItemResponse>> purchaseItem(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @PathVariable Long itemId
+            @PathVariable int identifier
     ) {
-        ItemResponse itemResponse = itemService.orderItem(userPrincipal.getUser(), itemId);
+        Item item = itemProvider.findByIdentifier(identifier);
+        ItemResponse itemResponse = itemService.orderItem(userPrincipal.getUser(), item.getId());
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), itemResponse)
         );
     }
 
-    @PostMapping("/items/use/{itemId}")
+    @PostMapping("/items/use/{identifier}")
     public ResponseEntity<CommonResponse> useItem(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @PathVariable Long itemId,
+            @PathVariable int identifier,
             @RequestParam(required = false) Long instanceId
     ) {
-        ItemUseResponse itemUseResponse = itemService.useItem(userPrincipal.getUser(), itemId, instanceId,
-                LocalDate.now());
+        Item item = itemProvider.findByIdentifier(identifier);
+        ItemUseResponse itemUseResponse = itemService.useItem(userPrincipal.getUser(), item.getId(),
+                instanceId, LocalDate.now());
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), itemUseResponse)

--- a/src/main/java/com/genius/gitget/store/item/domain/Item.java
+++ b/src/main/java/com/genius/gitget/store/item/domain/Item.java
@@ -41,9 +41,11 @@ public class Item extends BaseTimeEntity {
     private String details;
 
     @Builder
-    public Item(String name, int cost, ItemCategory itemCategory, String details) {
+    public Item(String name, int cost, int identifier,
+                ItemCategory itemCategory, String details) {
         this.name = name;
         this.cost = cost;
+        this.identifier = identifier;
         this.itemCategory = itemCategory;
         this.details = details;
     }

--- a/src/main/java/com/genius/gitget/store/item/domain/Item.java
+++ b/src/main/java/com/genius/gitget/store/item/domain/Item.java
@@ -28,6 +28,9 @@ public class Item extends BaseTimeEntity {
     @OneToMany(mappedBy = "item")
     private List<Orders> ordersList = new ArrayList<>();
 
+    @Column(unique = true)
+    private int identifier;
+
     private String name;
 
     private int cost;

--- a/src/main/java/com/genius/gitget/store/item/dto/ItemResponse.java
+++ b/src/main/java/com/genius/gitget/store/item/dto/ItemResponse.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Data
 public class ItemResponse {
-    private Long itemId;
+    private int itemId;
     private ItemCategory itemCategory;
     private String name;
     private String details;
@@ -14,7 +14,7 @@ public class ItemResponse {
     private int count;
 
     protected ItemResponse(Item item, int count) {
-        this.itemId = item.getId();
+        this.itemId = item.getIdentifier();
         this.itemCategory = item.getItemCategory();
         this.name = item.getName();
         this.details = item.getDetails();

--- a/src/main/java/com/genius/gitget/store/item/repository/ItemRepository.java
+++ b/src/main/java/com/genius/gitget/store/item/repository/ItemRepository.java
@@ -3,6 +3,7 @@ package com.genius.gitget.store.item.repository;
 import com.genius.gitget.store.item.domain.Item;
 import com.genius.gitget.store.item.domain.ItemCategory;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +12,6 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     @Query("select i from Item i where i.itemCategory = :category")
     List<Item> findAllByCategory(@Param("category") ItemCategory itemCategory);
+
+    Optional<Item> findByIdentifier(@Param("identifier") int identifier);
 }

--- a/src/main/java/com/genius/gitget/store/item/service/ItemProvider.java
+++ b/src/main/java/com/genius/gitget/store/item/service/ItemProvider.java
@@ -1,10 +1,10 @@
 package com.genius.gitget.store.item.service;
 
+import com.genius.gitget.global.util.exception.BusinessException;
+import com.genius.gitget.global.util.exception.ErrorCode;
 import com.genius.gitget.store.item.domain.Item;
 import com.genius.gitget.store.item.domain.ItemCategory;
 import com.genius.gitget.store.item.repository.ItemRepository;
-import com.genius.gitget.global.util.exception.BusinessException;
-import com.genius.gitget.global.util.exception.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +18,11 @@ public class ItemProvider {
 
     public Item findById(Long itemId) {
         return itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+    }
+
+    public Item findByIdentifier(int identifier) {
+        return itemRepository.findByIdentifier(identifier)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
     }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,21 +1,25 @@
-INSERT INTO item (cost, created_at, deleted_at, updated_at, details, name, item_category)
+INSERT INTO item (identifier, cost, details, name, item_category)
 SELECT *
-FROM (SELECT 100                    AS cost,
-             NULL                   AS created_at,
-             NULL                   AS deleted_at,
-             NULL                   AS updated_at,
+FROM (SELECT 1                      AS identifier,
+             100                    AS cost,
              '프로필을 꾸밀 수 있는 프레임입니다.' AS details,
              '성탄절 프레임'              AS name,
              'PROFILE_FRAME'        AS item_category
       UNION ALL
-      SELECT 100, NULL, NULL, NULL, '프로필을 꾸밀 수 있는 프레임입니다.', '어둠의 힘 프레임', 'PROFILE_FRAME'
+      SELECT 2,
+             100,
+             '프로필을 꾸밀 수 있는 프레임입니다.',
+             '어둠의 힘 프레임',
+             'PROFILE_FRAME'
       UNION ALL
-      SELECT 100, NULL, NULL, NULL, '오늘의 인증을 넘길 수 있는 아이템입니다.', '인증 패스권', 'CERTIFICATION_PASSER'
+      SELECT 3,
+             100,
+             '오늘의 인증을 넘길 수 있는 아이템입니다.',
+             '인증 패스권',
+             'CERTIFICATION_PASSER'
       UNION ALL
-      SELECT 100,
-             NULL,
-             NULL,
-             NULL,
+      SELECT 4,
+             100,
              '아이템 사용 시, 챌린지 성공 보상을 2배로 획득할 수 있는 아이템입니다.',
              '챌린지 보상 획득 2배 아이템',
              'POINT_MULTIPLIER') AS new_items

--- a/src/test/java/com/genius/gitget/challenge/item/service/ItemProviderTest.java
+++ b/src/test/java/com/genius/gitget/challenge/item/service/ItemProviderTest.java
@@ -1,13 +1,14 @@
 package com.genius.gitget.challenge.item.service;
 
+import static com.genius.gitget.store.item.domain.ItemCategory.CERTIFICATION_PASSER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.genius.gitget.global.util.exception.BusinessException;
+import com.genius.gitget.global.util.exception.ErrorCode;
 import com.genius.gitget.store.item.domain.Item;
 import com.genius.gitget.store.item.domain.ItemCategory;
 import com.genius.gitget.store.item.repository.ItemRepository;
-import com.genius.gitget.global.util.exception.BusinessException;
-import com.genius.gitget.global.util.exception.ErrorCode;
 import com.genius.gitget.store.item.service.ItemProvider;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +35,7 @@ class ItemProviderTest {
     @EnumSource(mode = Mode.INCLUDE, names = {"POINT_MULTIPLIER", "CERTIFICATION_PASSER"})
     public void should_findItems_when_passCategory(ItemCategory itemCategory) {
         //given
-        Item item = getSavedItem(itemCategory);
+        Item item = getSavedItem(10, itemCategory);
 
         //when
         List<Item> items = itemProvider.findAllByCategory(itemCategory);
@@ -49,7 +50,7 @@ class ItemProviderTest {
     @DisplayName("DB에 저장되어 있는 아이템을 식별자 PK를 통해 조회할 수 있다.")
     public void should_findItem_when_passPK() {
         //given
-        Item item = getSavedItem(ItemCategory.CERTIFICATION_PASSER);
+        Item item = getSavedItem(10, CERTIFICATION_PASSER);
 
         //when
         Item foundItem = itemProvider.findById(item.getId());
@@ -68,9 +69,25 @@ class ItemProviderTest {
                 .hasMessageContaining(ErrorCode.ITEM_NOT_FOUND.getMessage());
     }
 
-    private Item getSavedItem(ItemCategory itemCategory) {
+    @Test
+    @DisplayName("식별 전용 값인 identifier를 통해 아이템을 조회할 수 있다.")
+    public void should_findItem_by_identifier() {
+        //given
+        int identifier = 10;
+        Item item = getSavedItem(identifier, CERTIFICATION_PASSER);
+
+        //when
+        Item byIdentifier = itemProvider.findByIdentifier(identifier);
+
+        //then
+        assertThat(item.getId()).isEqualTo(byIdentifier.getId());
+        assertThat(byIdentifier.getItemCategory()).isEqualTo(CERTIFICATION_PASSER);
+    }
+
+    private Item getSavedItem(int identifier, ItemCategory itemCategory) {
         return itemRepository.save(
                 Item.builder()
+                        .identifier(identifier)
                         .cost(100)
                         .itemCategory(itemCategory)
                         .build()

--- a/src/test/java/com/genius/gitget/challenge/item/service/ItemServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/item/service/ItemServiceTest.java
@@ -113,7 +113,7 @@ class ItemServiceTest {
         ItemResponse itemResponse = itemService.orderItem(user, item.getId());
 
         //then
-        assertThat(itemResponse.getItemId()).isEqualTo(item.getId());
+        assertThat(itemResponse.getItemId()).isEqualTo(item.getIdentifier());
         assertThat(itemResponse.getName()).isEqualTo(item.getName());
         assertThat(itemResponse.getCost()).isEqualTo(item.getCost());
         assertThat(itemResponse.getCount()).isEqualTo(1);
@@ -416,7 +416,7 @@ class ItemServiceTest {
         ProfileResponse profileResponse = itemService.unmountFrame(user).get(0);
 
         //then
-        assertThat(profileResponse.getItemId()).isEqualTo(item.getId());
+        assertThat(profileResponse.getItemId()).isEqualTo(item.getIdentifier());
         assertThat(profileResponse.getCost()).isEqualTo(item.getCost());
         assertThat(profileResponse.getItemCategory()).isEqualTo(ItemCategory.PROFILE_FRAME);
         assertThat(profileResponse.getEquipStatus()).isEqualTo(EquipStatus.AVAILABLE.getTag());
@@ -466,6 +466,7 @@ class ItemServiceTest {
 
     private Item getSavedItem(ItemCategory itemCategory) {
         return itemRepository.save(Item.builder()
+                .identifier(10)
                 .itemCategory(itemCategory)
                 .cost(100)
                 .name(itemCategory.getName())


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/188-item-identifier-bug` → `main`

</br>

### 변경 사항
> FE에서 Item의 식별 코드(현재에는 item_id)를 전달받아 식별 코드에 해당하는 이미지를 사용하는데,
> `data.sql`을 통해 아이템들을 저장하는 과정에서 식별 코드가 제대로 설정되지 않아, FE에서 적절한 이미지를 사용하지 못하는 버그를  픽스합니다.
> 
> 식별 코드를 담당하는 column을 새로 만들고, `data.sql`의 insert문도 적절하게 변경합니다.

#### 작업 상세 내용
- [x] 식별 코드를 담당하는 column인 `identifier`을 새로 만듭니다.
    - [x] `ItemResponse`의 `itemId`에 기존에 Item 테이블의 PK인 item_id를 반환하던 로직에서, identifier를 반환하도록 변경
- [x] `data.sql`의 insert문을 변경된 구조에 맞게 수정합니다.
- [x] `ItemController`의 `purchaseItem()`, `useItem()` 메서드에서 API를 통해 전달받은 값(식별자)를 통해 Item을 찾은 후, PK를 전달하도록 변경

#### 주의 사항
DB table의 구조가 변경되기 때문에, 추후 `main`, `production` 브랜치에 merge 이후 Local / Production 환경의 DB를 수정해야 합니다.

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/4efce963-8981-44ac-8335-f3e08b79fd18)


</br>

### 연관된 이슈
#188 

</br>

### 리뷰 요구사항(선택)
> Item 테이블에서 식별용으로 사용할 Column의 이름을 `identifier`로 설정했는데, 더 좋은 이름이 있을까요?
