### PR TITLE
[FEAT] 프로필 프레임 아이템 추가

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -18,5 +18,24 @@ FROM (SELECT 100                    AS cost,
              NULL,
              '아이템 사용 시, 챌린지 성공 보상을 2배로 획득할 수 있는 아이템입니다.',
              '챌린지 보상 획득 2배 아이템',
-             'POINT_MULTIPLIER') AS new_items
+             'POINT_MULTIPLIER'
+
+      UNION ALL
+      SELECT 5,
+             100,
+             '프로필을 꾸밀 수 있는 프레임입니다.',
+             '불태워라 프레임',
+             'PROFILE_FRAME'
+      UNION ALL
+      SELECT 6,
+             100,
+             '프로필을 꾸밀 수 있는 프레임입니다.',
+             '끈적이는 프레임',
+             'PROFILE_FRAME'
+      UNION ALL
+      SELECT 7,
+             100,
+             '프로필을 꾸밀 수 있는 프레임입니다.',
+             '무섭지롱 프레임',
+             'PROFILE_FRAME') AS new_items
 WHERE (SELECT COUNT(*) FROM item) < 3;

--- a/src/test/java/com/genius/gitget/challenge/item/service/ItemServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/item/service/ItemServiceTest.java
@@ -77,7 +77,7 @@ class ItemServiceTest {
         List<ItemResponse> items = itemService.getAllItems(user);
 
         //then
-        assertThat(items.size()).isEqualTo(4);
+        assertThat(items.size()).isGreaterThan(1);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가

□ 기능 삭제

□ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/190-add-profile-frame` → `main`

</br>

### 변경 사항
> `data.sql`의 `insert`문에 프로필 프레임 3개 추가

#### 작업 상세 내용
- [x] `data.sql`의 `insert`문에 프로필 3개를 추가하는 쿼리문을 추가로 작성합니다. 
        기존의 아이템 뒤에 추가로 3개의 항목(불태워라 프레임, 끈적이는 프레임, 무섭지롱 프레임)이 추가되었습니다.
 
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/31e50449-af87-47b7-b96f-8f6887045c0d)

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/b255d095-93a5-4373-aa43-2bd30027a59a)

</br>

### 연관된 이슈
#190 

</br>

### 리뷰 요구사항(선택)
> 
