### PR TITLE
[FIX] 당일에 시작하는 챌린지에 참여할 수 있는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceDetailController.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceDetailController.java
@@ -1,6 +1,7 @@
 package com.genius.gitget.challenge.instance.controller;
 
 import static com.genius.gitget.global.util.exception.SuccessCode.JOIN_SUCCESS;
+import static com.genius.gitget.global.util.exception.SuccessCode.QUIT_SUCCESS;
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
 import com.genius.gitget.challenge.instance.dto.detail.InstanceResponse;
@@ -9,6 +10,7 @@ import com.genius.gitget.challenge.instance.dto.detail.JoinResponse;
 import com.genius.gitget.challenge.instance.service.InstanceDetailService;
 import com.genius.gitget.global.security.domain.UserPrincipal;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +53,7 @@ public class InstanceDetailController {
         JoinRequest joinRequest = JoinRequest.builder()
                 .instanceId(instanceId)
                 .repository(repo)
+                .todayDate(LocalDate.now())
                 .build();
         JoinResponse joinResponse = instanceDetailService.joinNewChallenge(userPrincipal.getUser(), joinRequest);
 
@@ -67,7 +70,7 @@ public class InstanceDetailController {
         JoinResponse joinResponse = instanceDetailService.quitChallenge(userPrincipal.getUser(), instanceId);
 
         return ResponseEntity.ok().body(
-                new SingleResponse<>(JOIN_SUCCESS.getStatus(), JOIN_SUCCESS.getMessage(), joinResponse)
+                new SingleResponse<>(QUIT_SUCCESS.getStatus(), QUIT_SUCCESS.getMessage(), joinResponse)
         );
     }
 }

--- a/src/main/java/com/genius/gitget/challenge/instance/dto/detail/JoinRequest.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/dto/detail/JoinRequest.java
@@ -1,10 +1,12 @@
 package com.genius.gitget.challenge.instance.dto.detail;
 
+import java.time.LocalDate;
 import lombok.Builder;
 
 @Builder
 public record JoinRequest(
         Long instanceId,
-        String repository
+        String repository,
+        LocalDate todayDate
 ) {
 }

--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
@@ -20,6 +20,7 @@ import com.genius.gitget.challenge.user.service.UserService;
 import com.genius.gitget.global.file.dto.FileResponse;
 import com.genius.gitget.global.file.service.FilesService;
 import com.genius.gitget.global.util.exception.BusinessException;
+import java.time.LocalDate;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,9 +70,9 @@ public class InstanceDetailService {
 
         String repository = joinRequest.repository();
 
-        if (!verifyGithub(persistUser, repository) || !canJoinChallenge(persistUser, instance)) {
-            throw new BusinessException(CAN_NOT_JOIN_INSTANCE);
-        }
+        validateJoinDate(instance, joinRequest.todayDate());
+        validateInstanceCondition(persistUser, instance);
+        validateGithub(persistUser, repository);
 
         instance.updateParticipantCount(1);
         Participant participant = Participant.createDefaultParticipant(repository);
@@ -79,17 +80,27 @@ public class InstanceDetailService {
         return JoinResponse.createJoinResponse(participantProvider.save(participant));
     }
 
-    private boolean canJoinChallenge(User user, Instance instance) {
-        boolean b = !participantProvider.hasParticipant(user.getId(), instance.getId());
-        return (instance.getProgress() == Progress.PREACTIVITY) &&
-                !participantProvider.hasParticipant(user.getId(), instance.getId());
+    private void validateJoinDate(Instance instance, LocalDate todayDate) {
+        LocalDate startedDate = instance.getStartedDate().toLocalDate();
+
+        if (todayDate.isBefore(startedDate)) {
+            return;
+        }
+        throw new BusinessException(CAN_NOT_JOIN_INSTANCE);
     }
 
-    private boolean verifyGithub(User user, String repository) {
+    private void validateInstanceCondition(User user, Instance instance) {
+        boolean isParticipated = participantProvider.hasParticipant(user.getId(), instance.getId());
+        if ((instance.getProgress() == Progress.PREACTIVITY) && !isParticipated) {
+            return;
+        }
+        throw new BusinessException(CAN_NOT_JOIN_INSTANCE);
+    }
+
+    private void validateGithub(User user, String repository) {
         GitHub gitHub = githubProvider.getGithubConnection(user);
         String repositoryFullName = githubProvider.getRepoFullName(gitHub, repository);
         githubProvider.validateGithubRepository(gitHub, repositoryFullName);
-        return true;
     }
 
     @Transactional

--- a/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
     GITHUB_PR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레포지토리에 PR이 존재하지 않습니다."),
 
     CAN_NOT_JOIN_INSTANCE(HttpStatus.BAD_REQUEST, "해당 인스턴스에 참여할 수 없습니다."),
+    INVALID_JOIN_DATE(HttpStatus.BAD_REQUEST, "인스턴스 시작 당일에는 신규 참여할 수 없습니다."),
     CAN_NOT_QUIT_INSTANCE(HttpStatus.BAD_REQUEST, "해당 인스턴스의 참여를 취소할 수 없습니다."),
 
     PR_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "인증에 사용하는 PR의 내용에 PR Template가 포함되어야 합니다."),

--- a/src/main/java/com/genius/gitget/global/util/exception/SuccessCode.java
+++ b/src/main/java/com/genius/gitget/global/util/exception/SuccessCode.java
@@ -11,6 +11,7 @@ public enum SuccessCode {
     // 200 OK
     SUCCESS(HttpStatus.OK, "요청이 정상적으로 처리되었습니다."),
     JOIN_SUCCESS(HttpStatus.OK, "챌린지 참여가 정상적으로 처리되었습니다."),
+    QUIT_SUCCESS(HttpStatus.OK, "챌린지 참여 취소가 정상적으로 처리되었습니다."),
 
     // 201 CREATED
     CREATED(HttpStatus.CREATED, "정상적으로 생성되었습니다.");

--- a/src/test/java/com/genius/gitget/challenge/instance/service/InstanceDetailServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/instance/service/InstanceDetailServiceTest.java
@@ -26,6 +26,7 @@ import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.repository.UserRepository;
 import com.genius.gitget.global.security.constants.ProviderInfo;
 import com.genius.gitget.global.util.exception.BusinessException;
+import com.genius.gitget.global.util.exception.ErrorCode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -70,9 +71,11 @@ class InstanceDetailServiceTest {
         //given
         User savedUser = getSavedUser(githubId);
         Instance instance = getSavedInstance(Progress.PREACTIVITY);
+        LocalDate todayDate = LocalDate.of(2024, 1, 30);
         JoinRequest joinRequest = JoinRequest.builder()
                 .instanceId(instance.getId())
                 .repository(targetRepo)
+                .todayDate(todayDate)
                 .build();
 
         //when
@@ -107,9 +110,11 @@ class InstanceDetailServiceTest {
         //given
         User savedUser = getSavedUser(githubId);
         Instance savedInstance = getSavedInstance(progress);
+        LocalDate todayDate = LocalDate.of(2024, 1, 30);
         JoinRequest joinRequest = JoinRequest.builder()
                 .repository(targetRepo)
                 .instanceId(savedInstance.getId())
+                .todayDate(todayDate)
                 .build();
 
         //when & then
@@ -124,9 +129,11 @@ class InstanceDetailServiceTest {
         //given
         User user = getSavedUser(githubId);
         Instance instance = getSavedInstance(Progress.PREACTIVITY);
+        LocalDate todayDate = LocalDate.of(2024, 1, 30);
         JoinRequest joinRequest = JoinRequest.builder()
                 .repository(targetRepo)
                 .instanceId(instance.getId())
+                .todayDate(todayDate)
                 .build();
 
         //when
@@ -139,14 +146,36 @@ class InstanceDetailServiceTest {
     }
 
     @Test
+    @DisplayName("챌린지 시작 당일에 챌린지 참여 요청을 하면 예외가 발생한다")
+    public void should_throwException_when_joinAtStartedDate() {
+        //given
+        LocalDate today = LocalDate.of(2024, 1, 30);
+
+        User user = getSavedUser(githubId);
+        Instance instance = getSavedInstance(Progress.PREACTIVITY, today);
+        JoinRequest joinRequest = JoinRequest.builder()
+                .repository(targetRepo)
+                .instanceId(instance.getId())
+                .todayDate(today)
+                .build();
+
+        //when
+        assertThatThrownBy(() -> instanceDetailService.joinNewChallenge(user, joinRequest))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.CAN_NOT_JOIN_INSTANCE.getMessage());
+    }
+
+    @Test
     @DisplayName("아직 시작하지 않은 챌린지에 대해 취소 요청을 하면 ParticipantInfo가 삭제된다.")
     public void should_joinStatusIsNo_when_quitChallenge() {
         //given
         User savedUser = getSavedUser(githubId);
         Instance savedInstance = getSavedInstance(Progress.PREACTIVITY);
+        LocalDate todayDate = LocalDate.of(2024, 1, 30);
 
         //when
-        instanceDetailService.joinNewChallenge(savedUser, new JoinRequest(savedInstance.getId(), targetRepo));
+        instanceDetailService.joinNewChallenge(savedUser,
+                new JoinRequest(savedInstance.getId(), targetRepo, todayDate));
         JoinResponse joinResponse = instanceDetailService.quitChallenge(savedUser, savedInstance.getId());
 
         //then
@@ -162,9 +191,11 @@ class InstanceDetailServiceTest {
         //given
         User savedUser = getSavedUser(githubId);
         Instance savedInstance = getSavedInstance(Progress.PREACTIVITY);
+        LocalDate todayDate = LocalDate.of(2024, 1, 30);
         JoinRequest joinRequest = JoinRequest.builder()
                 .instanceId(savedInstance.getId())
                 .repository(targetRepo)
+                .todayDate(todayDate)
                 .build();
 
         //when
@@ -211,9 +242,11 @@ class InstanceDetailServiceTest {
         //given
         User savedUser = getSavedUser(githubId);
         Instance savedInstance = getSavedInstance(Progress.PREACTIVITY);
+        LocalDate todayDate = LocalDate.of(2024, 1, 30);
         JoinRequest joinRequest = JoinRequest.builder()
                 .instanceId(savedInstance.getId())
                 .repository(targetRepo)
+                .todayDate(todayDate)
                 .build();
 
         //when
@@ -232,9 +265,11 @@ class InstanceDetailServiceTest {
         //given
         User savedUser = getSavedUser(githubId);
         Instance savedInstance = getSavedInstance(Progress.PREACTIVITY, LocalDate.now().plusDays(2));
+        LocalDate todayDate = LocalDate.of(2024, 1, 30);
         JoinRequest joinRequest = JoinRequest.builder()
                 .instanceId(savedInstance.getId())
                 .repository(targetRepo)
+                .todayDate(todayDate)
                 .build();
 
         //when

--- a/src/test/java/com/genius/gitget/challenge/instance/service/ProgressServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/instance/service/ProgressServiceTest.java
@@ -66,6 +66,7 @@ class ProgressServiceTest {
     @DisplayName("PRE_ACTIVITY 인스턴스들 중, 특정 조건에 해당하는 인스턴스들을 ACTIVITY로 상태를 바꿀 수 있다.")
     public void should_updateToActivity_when_conditionMatches() {
         //given
+        LocalDate todayDate = LocalDate.of(2024, 1, 30);
         LocalDate startedDate = LocalDate.of(2024, 3, 1);
         LocalDate completedDate = LocalDate.of(2024, 3, 30);
         LocalDate currentDate = LocalDate.of(2024, 3, 6);
@@ -81,6 +82,7 @@ class ProgressServiceTest {
                 JoinRequest.builder()
                         .repository(targetRepo)
                         .instanceId(instance1.getId())
+                        .todayDate(todayDate)
                         .build()
         );
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/193-challenge-join-condition` → `main`

</br>

### 변경 사항
> 당일에 시작하는 챌린지에 참여할 수 있는 버그를 수정합니다.
> As-Is: 당일에 시작하는 챌린지에 참여할 수 있음
> To-be: 당일에 시작하는 챌린지에 참여할 수 없음

#### 작업 상세 내용
- [x] `JoinNewChallenge`에 인스턴스 참여 가능 여부를 검증하는 로직을  추가하여 당일에 시작하는 챌린지에 참여할 수 없도록 수정
    - [x] `validateJoinDate(instance, joinRequest.todayDate())`: 현재 날짜가 인스턴스 시작 날짜보다 이전인지 확인
    - [x] `validateInstanceCondition(persistUser, instance)`: 인스턴스가 시작 전 상태인지 & 이미 참여처리되어 있지 않은지 확인
    - [x] `validateGithub(persistUser, repository)`: 사용자의 Github 토큰 & 선택한 Repository 유효성 확인
- [x] `InstanceDetailServiceTest`에 현재 날짜가 인스턴스 시작 당일일 때 예외를 발생시킨는지 확인하는 테스트 코드 추가

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/0e242473-4312-48cd-8965-fedace77b9b2)


</br>

### 연관된 이슈
#193 

</br>

### 리뷰 요구사항(선택)
> 