### PR TITLE
[FIX] 인스턴스 상세 조회 시 좋아요 개수 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/dto/detail/LikesInfo.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/dto/detail/LikesInfo.java
@@ -17,11 +17,11 @@ public record LikesInfo(
                 .build();
     }
 
-    public static LikesInfo createNotExist() {
+    public static LikesInfo createNotExist(int likesCount) {
         return LikesInfo.builder()
                 .likesId(0L)
                 .isLiked(false)
-                .likesCount(0)
+                .likesCount(likesCount)
                 .build();
     }
 }

--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
@@ -59,7 +59,7 @@ public class InstanceDetailService {
             return LikesInfo.createExist(likes.getId(), instance.getLikesCount());
         }
 
-        return LikesInfo.createNotExist();
+        return LikesInfo.createNotExist(instance.getLikesCount());
     }
 
     @Transactional


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`bug/192-like-count` → `main`

</br>

### 변경 사항
- [x] 사용자가 해당 인스턴스에 좋아요를 하지 않았을 때, 좋아요 개수를 0으로 보내던 문제 해결
    - [x] LikesInfo의 createNotExist에서 likesCount를 0으로 고정하여 반환하여 문제가 발생 → likesCount를 전달받아서 값 대입하도록 수정

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/28ed679f-8908-4286-b694-8823565667c3)


</br>

### 연관된 이슈
#192

</br>

### 리뷰 요구사항(선택)
> 
