### PR TITLE
[FIX] 챌린지 시작 당일이 되었을 때 상태가 업데이트 되도록 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/schedule/service/ProgressService.java
+++ b/src/main/java/com/genius/gitget/schedule/service/ProgressService.java
@@ -33,10 +33,14 @@ public class ProgressService {
             LocalDate startedDate = preActivity.getStartedDate().toLocalDate();
             LocalDate completedDate = preActivity.getCompletedDate().toLocalDate();
 
-            if (currentDate.isAfter(startedDate) && currentDate.isBefore(completedDate)) {
+            if (isUpdatableToActivity(startedDate, currentDate) && currentDate.isBefore(completedDate)) {
                 updateActivityInstance(preActivity);
             }
         }
+    }
+
+    private boolean isUpdatableToActivity(LocalDate startedDate, LocalDate currentDate) {
+        return currentDate.isEqual(startedDate) || currentDate.isAfter(startedDate);
     }
 
     private void updateActivityInstance(Instance preActivity) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/202-progress-update-scheduler` → `main`

</br>

### 변경 사항
- [x] `ProgressService` - `updateToActivity()`의 조건문에서 챌린지 시작 당일일 때에도 상태 업데이트가 되도록 수정
    - [x] `isUpdatableToActivity`에서 `현재 일자` >= `챌린지 시작일`인지 확인 후, 맞으면 true 반환
- [x] 챌린지 시작 당일에도 업데이트가 되는지 여부를 확인하는 테스트 코드 추가

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/5a95667b-a27b-4d20-9e29-34c61cbb229f)


</br>

### 연관된 이슈
#202 

</br>

### 리뷰 요구사항(선택)
>
