### PR TITLE
[FIX] UTC 기준의 시간을 KST로 변환이 되지 않던 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/service/GithubProvider.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/GithubProvider.java
@@ -112,7 +112,7 @@ public class GithubProvider {
 
     private boolean isEqualToKST(GHPullRequest ghPullRequest, LocalDate targetDate) {
         try {
-            LocalDate kst = DateUtil.convertToLocalDate(ghPullRequest.getCreatedAt());
+            LocalDate kst = DateUtil.convertToKST(ghPullRequest.getCreatedAt());
             return kst.isEqual(targetDate);
         } catch (IOException e) {
             throw new BusinessException(e);

--- a/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
@@ -5,7 +5,9 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public final class DateUtil {
 
     public static int getRemainDaysToStart(LocalDate startDate, LocalDate targetDate) {
@@ -39,7 +41,7 @@ public final class DateUtil {
     }
 
     public static LocalDate convertToKST(Date date) {
-        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.of("UTC"))
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault())
                 .plusHours(9)
                 .toLocalDate();
     }

--- a/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
@@ -39,7 +39,7 @@ public final class DateUtil {
     }
 
     public static LocalDate convertToKST(Date date) {
-        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.of("Asia/Seoul"))
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault())
                 .plusHours(9)
                 .toLocalDate();
     }

--- a/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
@@ -39,7 +39,7 @@ public final class DateUtil {
     }
 
     public static LocalDate convertToKST(Date date) {
-        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault())
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.of("UTC"))
                 .plusHours(9)
                 .toLocalDate();
     }
@@ -47,7 +47,7 @@ public final class DateUtil {
     private static boolean isFirstWeek(LocalDate challengeStartDate, LocalDate currentDate) {
         LocalDate mondayOfWeek = challengeStartDate.minusDays(challengeStartDate.getDayOfWeek().ordinal());
         LocalDate sundayOfWeek = mondayOfWeek.plusDays(6);
-        
+
         if (currentDate.isAfter(mondayOfWeek.minusDays(1))
                 && currentDate.isBefore(sundayOfWeek.plusDays(1))) {
             return true;

--- a/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
@@ -1,6 +1,7 @@
 package com.genius.gitget.challenge.certification.util;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -37,11 +38,10 @@ public final class DateUtil {
         return mondayOfWeek;
     }
 
-    public static LocalDate convertToLocalDate(Date date) {
-        return LocalDate.ofInstant(
-                date.toInstant(),
-                ZoneId.of("Asia/Seoul")
-        );
+    public static LocalDate convertToKST(Date date) {
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.of("Asia/Seoul"))
+                .plusHours(9)
+                .toLocalDate();
     }
 
     private static boolean isFirstWeek(LocalDate challengeStartDate, LocalDate currentDate) {

--- a/src/test/java/com/genius/gitget/challenge/certification/service/GithubProviderTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/service/GithubProviderTest.java
@@ -96,7 +96,7 @@ class GithubProviderTest {
     public void should_checkPR_when_validRepo() {
         //given
         GitHub gitHub = getGitHub();
-        LocalDate createdAt = LocalDate.of(2024, 2, 5);
+        LocalDate createdAt = LocalDate.of(2024, 6, 10);
 
         //when
         List<GHPullRequest> pullRequest = githubProvider.getPullRequestByDate(gitHub, repository, createdAt);

--- a/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
@@ -61,15 +61,15 @@ class DateUtilTest {
     public void should_convertToLocalDate_when_passDate() {
         //given
         //KST = UTC + 9:00
-        LocalDateTime targetDateTime1 = LocalDateTime.of(2024, 6, 9, 0, 0);
-        LocalDateTime targetDateTime2 = LocalDateTime.of(2024, 6, 9, 14, 59);
+        LocalDateTime utcTime1 = LocalDateTime.of(2024, 6, 9, 0, 0);
+        LocalDateTime utcTime2 = LocalDateTime.of(2024, 6, 9, 14, 59);
 
-        Date date1 = Timestamp.valueOf(targetDateTime1);
-        Date date2 = Timestamp.valueOf(targetDateTime2);
+        Date utcDate1 = Timestamp.valueOf(utcTime1);
+        Date utcDate2 = Timestamp.valueOf(utcTime2);
 
         //when
-        LocalDate localDate1 = DateUtil.convertToKST(date1);
-        LocalDate localDate2 = DateUtil.convertToKST(date2);
+        LocalDate localDate1 = DateUtil.convertToKST(utcDate1);
+        LocalDate localDate2 = DateUtil.convertToKST(utcDate2);
 
         //then
         assertThat(localDate1).isEqualTo(LocalDate.of(2024, 6, 9));

--- a/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
@@ -60,8 +60,10 @@ class DateUtilTest {
     @DisplayName("0시부터 14시 59분까지의 Date를 전달했을 때 KST 기준의 LocalDate로 변환할 수 있다.")
     public void should_convertToLocalDate_when_passDate() {
         //given
+        //KST = UTC + 9:00
         LocalDateTime targetDateTime1 = LocalDateTime.of(2024, 6, 9, 0, 0);
         LocalDateTime targetDateTime2 = LocalDateTime.of(2024, 6, 9, 14, 59);
+
         Date date1 = Timestamp.valueOf(targetDateTime1);
         Date date2 = Timestamp.valueOf(targetDateTime2);
 

--- a/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
@@ -57,16 +57,21 @@ class DateUtilTest {
     }
 
     @Test
-    @DisplayName("Date를 전달했을 때 LocalDate로 변환할 수 있다.")
+    @DisplayName("0시부터 14시 59분까지의 Date를 전달했을 때 KST 기준의 LocalDate로 변환할 수 있다.")
     public void should_convertToLocalDate_when_passDate() {
         //given
-        Date date = new Date(1725000000000L);
+        LocalDateTime targetDateTime1 = LocalDateTime.of(2024, 6, 9, 0, 0);
+        LocalDateTime targetDateTime2 = LocalDateTime.of(2024, 6, 9, 14, 59);
+        Date date1 = Timestamp.valueOf(targetDateTime1);
+        Date date2 = Timestamp.valueOf(targetDateTime2);
 
         //when
-        LocalDate localDate = DateUtil.convertToKST(date);
+        LocalDate localDate1 = DateUtil.convertToKST(date1);
+        LocalDate localDate2 = DateUtil.convertToKST(date2);
 
         //then
-        assertThat(localDate).isEqualTo(LocalDate.of(2024, 8, 30));
+        assertThat(localDate1).isEqualTo(LocalDate.of(2024, 6, 9));
+        assertThat(localDate2).isEqualTo(LocalDate.of(2024, 6, 9));
     }
 
     @Test

--- a/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
@@ -2,8 +2,10 @@ package com.genius.gitget.challenge.certification.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Timestamp;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -61,10 +63,27 @@ class DateUtilTest {
         Date date = new Date(1725000000000L);
 
         //when
-        LocalDate localDate = DateUtil.convertToLocalDate(date);
+        LocalDate localDate = DateUtil.convertToKST(date);
 
         //then
         assertThat(localDate).isEqualTo(LocalDate.of(2024, 8, 30));
+    }
+
+    @Test
+    @DisplayName("UTC 기준 15시 이후의 시간을 KST로 변환하면 다음 날로 인식이 되어야 한다.")
+    public void should_convertToKST() {
+        // 2024-06-09T23:35:12Z
+        LocalDateTime targetDateTime1 = LocalDateTime.of(2024, 6, 9, 15, 0);
+        LocalDateTime targetDateTime2 = LocalDateTime.of(2024, 6, 9, 23, 35);
+
+        Date date1 = Timestamp.valueOf(targetDateTime1);
+        Date date2 = Timestamp.valueOf(targetDateTime2);
+
+        LocalDate kst1 = DateUtil.convertToKST(date1);
+        LocalDate kst2 = DateUtil.convertToKST(date2);
+
+        assertThat(kst1).isEqualTo(LocalDate.of(2024, 6, 10));
+        assertThat(kst2).isEqualTo(LocalDate.of(2024, 6, 10));
     }
 
     @Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/204-PR-recognize-bug` → `main`

</br>

### 변경 사항
- [x] UTC 기준의 시간이 KST로 제대로 변환이 되지 않아 날짜가 하루 전 날로 나오는 버그 픽스
    - [x] .plusHours(9)를 통해 KST로 변환
- [x] 관련 테스트 코드 추가

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/cfd01aa1-22ad-48bf-a93a-60667389686d)


</br>

### 연관된 이슈
#204 

</br>

### 리뷰 요구사항(선택)
> 
