### PR TITLE
[FIX] 00시~오전 동안 PR 인식을 못하는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
@@ -79,8 +79,7 @@ public class CertificationController {
     ) {
         User user = userPrincipal.getUser();
         ActivatedResponse activatedResponse = certificationService.passCertification(
-                user.getId(),
-                new CertificationRequest(certificationRequest.instanceId(), LocalDate.now()));
+                user.getId(), certificationRequest);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), activatedResponse)
@@ -92,9 +91,9 @@ public class CertificationController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long instanceId
     ) {
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
         Participant participant = participantProvider.findByJoinInfo(userPrincipal.getUser().getId(), instanceId);
-        WeekResponse weekResponse = certificationService.getMyWeekCertifications(
-                participant.getId(), LocalDate.now());
+        WeekResponse weekResponse = certificationService.getMyWeekCertifications(participant.getId(), kstDate);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), weekResponse)
@@ -107,9 +106,10 @@ public class CertificationController {
             @PathVariable Long instanceId,
             @PageableDefault Pageable pageable
     ) {
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
         User user = userPrincipal.getUser();
         Slice<WeekResponse> certifications = certificationService.getOthersWeekCertifications(
-                user.getId(), instanceId, LocalDate.now(), pageable);
+                user.getId(), instanceId, kstDate, pageable);
 
         return ResponseEntity.ok().body(
                 new SlicingResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), certifications)
@@ -121,10 +121,11 @@ public class CertificationController {
             @PathVariable Long instanceId,
             @RequestParam Long userId
     ) {
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
         User user = userService.findUserById(userId);
         Participant participant = participantProvider.findByJoinInfo(user.getId(), instanceId);
         TotalResponse totalResponse = certificationService.getTotalCertification(
-                participant.getId(), LocalDate.now());
+                participant.getId(), kstDate);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), totalResponse)

--- a/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
@@ -63,8 +63,7 @@ public class CertificationController {
             @RequestBody CertificationRequest certificationRequest
     ) {
         CertificationResponse certificationResponse = certificationService.updateCertification(
-                userPrincipal.getUser(),
-                new CertificationRequest(certificationRequest.instanceId(), LocalDate.now()));
+                userPrincipal.getUser(), certificationRequest);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), certificationResponse)

--- a/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
@@ -9,6 +9,7 @@ import com.genius.gitget.challenge.certification.dto.InstancePreviewResponse;
 import com.genius.gitget.challenge.certification.dto.TotalResponse;
 import com.genius.gitget.challenge.certification.dto.WeekResponse;
 import com.genius.gitget.challenge.certification.service.CertificationService;
+import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.service.InstanceProvider;
 import com.genius.gitget.challenge.myChallenge.dto.ActivatedResponse;
@@ -20,6 +21,7 @@ import com.genius.gitget.global.security.domain.UserPrincipal;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import com.genius.gitget.global.util.response.dto.SlicingResponse;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -135,13 +137,14 @@ public class CertificationController {
             @PathVariable Long instanceId
     ) {
 
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
         Instance instance = instanceProvider.findById(instanceId);
         Participant participant = participantProvider.findByJoinInfo(
                 userPrincipal.getUser().getId(),
                 instanceId);
 
         CertificationInformation certificationInformation = certificationService.getCertificationInformation(
-                instance, participant, LocalDate.now());
+                instance, participant, kstDate);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), certificationInformation)

--- a/src/main/java/com/genius/gitget/challenge/certification/controller/GithubController.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/controller/GithubController.java
@@ -5,10 +5,11 @@ import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 import com.genius.gitget.challenge.certification.dto.github.GithubTokenRequest;
 import com.genius.gitget.challenge.certification.dto.github.PullRequestResponse;
 import com.genius.gitget.challenge.certification.service.GithubService;
+import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.global.security.domain.UserPrincipal;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.ListResponse;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,7 +57,7 @@ public class GithubController {
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
         githubService.verifyGithubToken(userPrincipal.getUser());
-        
+
         return ResponseEntity.ok().body(
                 new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage())
         );
@@ -82,7 +83,7 @@ public class GithubController {
     ) {
 
         List<PullRequestResponse> pullRequestResponses = githubService.verifyPullRequest(
-                userPrincipal.getUser(), repo, LocalDate.now()
+                userPrincipal.getUser(), repo, DateUtil.convertToKST(LocalDateTime.now())
         );
 
         return ResponseEntity.ok().body(

--- a/src/main/java/com/genius/gitget/challenge/certification/service/GithubProvider.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/GithubProvider.java
@@ -112,7 +112,7 @@ public class GithubProvider {
 
     private boolean isEqualToKST(GHPullRequest ghPullRequest, LocalDate targetDate) {
         try {
-            LocalDate kst = DateUtil.convertToLocalDate(ghPullRequest.getCreatedAt());
+            LocalDate kst = DateUtil.convertToKST(ghPullRequest.getCreatedAt());
             return kst.isEqual(targetDate);
         } catch (IOException e) {
             throw new BusinessException(e);

--- a/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
@@ -1,10 +1,14 @@
 package com.genius.gitget.challenge.certification.util;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public final class DateUtil {
 
     public static int getRemainDaysToStart(LocalDate startDate, LocalDate targetDate) {
@@ -42,6 +46,20 @@ public final class DateUtil {
                 date.toInstant(),
                 ZoneId.of("Asia/Seoul")
         );
+    }
+
+    public static LocalDate convertToKST(LocalDateTime nowLocal) {
+        ZoneId systemZone = ZoneId.systemDefault();
+        ZoneId koreaZone = ZoneId.of("Asia/Seoul");
+
+        // 현재 시스템의 ZoneId를 이용하여 ZonedDateTime을 생성
+        ZonedDateTime nowZone = ZonedDateTime.of(nowLocal, systemZone);
+
+        // KST(Asia/Seoul)로 변환
+        ZonedDateTime koreaTime = nowZone.withZoneSameInstant(koreaZone);
+
+        // LocalDateTime으로 변환하여 반환
+        return koreaTime.toLocalDate();
     }
 
     private static boolean isFirstWeek(LocalDate challengeStartDate, LocalDate currentDate) {

--- a/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/util/DateUtil.java
@@ -37,7 +37,7 @@ public final class DateUtil {
         return mondayOfWeek;
     }
 
-    public static LocalDate convertToLocalDate(Date date) {
+    public static LocalDate convertToKST(Date date) {
         return LocalDate.ofInstant(
                 date.toInstant(),
                 ZoneId.of("Asia/Seoul")
@@ -47,7 +47,7 @@ public final class DateUtil {
     private static boolean isFirstWeek(LocalDate challengeStartDate, LocalDate currentDate) {
         LocalDate mondayOfWeek = challengeStartDate.minusDays(challengeStartDate.getDayOfWeek().ordinal());
         LocalDate sundayOfWeek = mondayOfWeek.plusDays(6);
-        
+
         if (currentDate.isAfter(mondayOfWeek.minusDays(1))
                 && currentDate.isBefore(sundayOfWeek.plusDays(1))) {
             return true;

--- a/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceController.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceController.java
@@ -3,6 +3,7 @@ package com.genius.gitget.challenge.instance.controller;
 import static com.genius.gitget.global.util.exception.SuccessCode.CREATED;
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
+import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceCreateRequest;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceDetailResponse;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceIndexResponse;
@@ -13,6 +14,7 @@ import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.PagingResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -75,7 +77,8 @@ public class InstanceController {
     @PostMapping("/instance")
     public ResponseEntity<SingleResponse<InstanceIndexResponse>> createInstance(
             @RequestBody InstanceCreateRequest instanceCreateRequest) {
-        Long instanceId = instanceService.createInstance(instanceCreateRequest, LocalDate.now());
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
+        Long instanceId = instanceService.createInstance(instanceCreateRequest, kstDate);
         InstanceIndexResponse instanceIndexResponse = new InstanceIndexResponse(instanceId);
 
         return ResponseEntity.ok().body(

--- a/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceDetailController.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceDetailController.java
@@ -4,6 +4,7 @@ import static com.genius.gitget.global.util.exception.SuccessCode.JOIN_SUCCESS;
 import static com.genius.gitget.global.util.exception.SuccessCode.QUIT_SUCCESS;
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
+import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.challenge.instance.dto.detail.InstanceResponse;
 import com.genius.gitget.challenge.instance.dto.detail.JoinRequest;
 import com.genius.gitget.challenge.instance.dto.detail.JoinResponse;
@@ -11,6 +12,7 @@ import com.genius.gitget.challenge.instance.service.InstanceDetailService;
 import com.genius.gitget.global.security.domain.UserPrincipal;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -50,10 +52,11 @@ public class InstanceDetailController {
             @PathVariable Long instanceId,
             @RequestParam String repo
     ) {
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
         JoinRequest joinRequest = JoinRequest.builder()
                 .instanceId(instanceId)
                 .repository(repo)
-                .todayDate(LocalDate.now())
+                .todayDate(kstDate)
                 .build();
         JoinResponse joinResponse = instanceDetailService.joinNewChallenge(userPrincipal.getUser(), joinRequest);
 

--- a/src/main/java/com/genius/gitget/challenge/instance/dto/detail/InstanceResponse.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/dto/detail/InstanceResponse.java
@@ -6,6 +6,7 @@ import com.genius.gitget.challenge.instance.domain.Progress;
 import com.genius.gitget.challenge.participant.domain.JoinStatus;
 import com.genius.gitget.global.file.dto.FileResponse;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -28,13 +29,14 @@ public record InstanceResponse(
 
     public static InstanceResponse createByEntity(Instance instance, LikesInfo likesInfo,
                                                   JoinStatus joinStatus, FileResponse fileResponse) {
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
         LocalDate startedLocalDate = instance.getStartedDate().toLocalDate();
         LocalDate completedLocalDate = instance.getCompletedDate().toLocalDate();
         return InstanceResponse.builder()
                 .instanceId(instance.getId())
                 .progress(instance.getProgress())
                 .title(instance.getTitle())
-                .remainDays(DateUtil.getRemainDaysToStart(startedLocalDate, LocalDate.now()))
+                .remainDays(DateUtil.getRemainDaysToStart(startedLocalDate, kstDate))
                 .startedDate(startedLocalDate)
                 .completedDate(completedLocalDate)
                 .participantCount(instance.getParticipantCount())

--- a/src/main/java/com/genius/gitget/challenge/myChallenge/controller/MyChallengeController.java
+++ b/src/main/java/com/genius/gitget/challenge/myChallenge/controller/MyChallengeController.java
@@ -2,6 +2,7 @@ package com.genius.gitget.challenge.myChallenge.controller;
 
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
+import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.challenge.myChallenge.dto.ActivatedResponse;
 import com.genius.gitget.challenge.myChallenge.dto.DoneResponse;
 import com.genius.gitget.challenge.myChallenge.dto.PreActivityResponse;
@@ -11,6 +12,7 @@ import com.genius.gitget.global.security.domain.UserPrincipal;
 import com.genius.gitget.global.util.response.dto.ListResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +37,7 @@ public class MyChallengeController {
     ) {
         List<PreActivityResponse> preActivityInstances = myChallengeService.getPreActivityInstances(
                 userPrincipal.getUser(),
-                LocalDate.now());
+                DateUtil.convertToKST(LocalDateTime.now()));
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), preActivityInstances)
@@ -49,7 +51,7 @@ public class MyChallengeController {
     ) {
         List<ActivatedResponse> activatedInstances = myChallengeService.getActivatedInstances(
                 userPrincipal.getUser(),
-                LocalDate.now());
+                DateUtil.convertToKST(LocalDateTime.now()));
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), activatedInstances)
@@ -62,7 +64,7 @@ public class MyChallengeController {
     ) {
         List<DoneResponse> doneInstances = myChallengeService.getDoneInstances(
                 userPrincipal.getUser(),
-                LocalDate.now());
+                DateUtil.convertToKST(LocalDateTime.now()));
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), doneInstances)
@@ -74,8 +76,8 @@ public class MyChallengeController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long instanceId
     ) {
-
-        RewardRequest rewardRequest = new RewardRequest(userPrincipal.getUser(), instanceId, LocalDate.now());
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
+        RewardRequest rewardRequest = new RewardRequest(userPrincipal.getUser(), instanceId, kstDate);
         DoneResponse doneResponse = myChallengeService.getRewards(rewardRequest, false);
 
         return ResponseEntity.ok().body(

--- a/src/main/java/com/genius/gitget/schedule/controller/ProgressController.java
+++ b/src/main/java/com/genius/gitget/schedule/controller/ProgressController.java
@@ -2,9 +2,11 @@ package com.genius.gitget.schedule.controller;
 
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
+import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.schedule.service.ProgressService;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +21,7 @@ public class ProgressController {
 
     @GetMapping("/challenges/update")
     public ResponseEntity<CommonResponse> updateProgress() {
-        LocalDate currentDate = LocalDate.now();
+        LocalDate currentDate = DateUtil.convertToKST(LocalDateTime.now());
         scheduleService.updateToActivity(currentDate);
         scheduleService.updateToDone(currentDate);
 

--- a/src/main/java/com/genius/gitget/schedule/service/ScheduleService.java
+++ b/src/main/java/com/genius/gitget/schedule/service/ScheduleService.java
@@ -1,6 +1,8 @@
 package com.genius.gitget.schedule.service;
 
+import com.genius.gitget.challenge.certification.util.DateUtil;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -17,11 +19,11 @@ public class ScheduleService {
     @Transactional
     @Scheduled(cron = "${schedule.cron}")
     public void run() {
-        LocalDate now = LocalDate.now();
+        LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
 
-        log.info(now + ": Schedule 설정에 따라 instance의 Progress 업데이트 진행");
+        log.info(kstDate + ": Schedule 설정에 따라 instance의 Progress 업데이트 진행");
 
-        scheduleService.updateToActivity(now);
-        scheduleService.updateToDone(now);
+        scheduleService.updateToActivity(kstDate);
+        scheduleService.updateToDone(kstDate);
     }
 }

--- a/src/main/java/com/genius/gitget/store/item/controller/ItemController.java
+++ b/src/main/java/com/genius/gitget/store/item/controller/ItemController.java
@@ -2,6 +2,7 @@ package com.genius.gitget.store.item.controller;
 
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
+import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.global.security.domain.UserPrincipal;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.ListResponse;
@@ -13,7 +14,7 @@ import com.genius.gitget.store.item.dto.ItemUseResponse;
 import com.genius.gitget.store.item.dto.ProfileResponse;
 import com.genius.gitget.store.item.service.ItemProvider;
 import com.genius.gitget.store.item.service.ItemService;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -71,7 +72,7 @@ public class ItemController {
     ) {
         Item item = itemProvider.findByIdentifier(identifier);
         ItemUseResponse itemUseResponse = itemService.useItem(userPrincipal.getUser(), item.getId(),
-                instanceId, LocalDate.now());
+                instanceId, DateUtil.convertToKST(LocalDateTime.now()));
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), itemUseResponse)

--- a/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
+++ b/src/test/java/com/genius/gitget/challenge/certification/util/DateUtilTest.java
@@ -61,7 +61,7 @@ class DateUtilTest {
         Date date = new Date(1725000000000L);
 
         //when
-        LocalDate localDate = DateUtil.convertToLocalDate(date);
+        LocalDate localDate = DateUtil.convertToKST(date);
 
         //then
         assertThat(localDate).isEqualTo(LocalDate.of(2024, 8, 30));


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/204-PR-recognize-bug` → `main`

</br>

### 변경 사항
- [x] `DateUtil`에 `LocalDateTime`을 받아서 KST로 변환된 `LocalDate`를 반환하는 메서드 `convertToKST()` 오버로딩 
        ZonedDateTime을 활용하여 시스템의 타임존을 고려하여 KST로 변환하는 메서드 작성
- [x] `/api/certification/today` API를 포함하여 `LocalDate.now()`가 사용된 곳을 모두 `convertToKST()`의 결과 값(KST로 변환된 일자)으로 변경

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/8ad77df3-3e41-4236-ba8d-cf32bb419fe4)

</br>

### 연관된 이슈
#204

</br>

### 리뷰 요구사항(선택)
> 
