### PR TITLE
[FIX] 인스턴스 참가 취소 시 인스턴스 참여 인원, 상태 변화에 대한 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/instance/domain/Instance.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/domain/Instance.java
@@ -144,6 +144,9 @@ public class Instance implements FileHolder {
      * 참가자 수 정보 수정
      * */
     public void updateParticipantCount(int amount) {
+        if (amount < 0 && this.participantCount + amount < 0) {
+            return;
+        }
         this.participantCount += amount;
     }
 

--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
@@ -46,7 +46,7 @@ public class InstanceDetailService {
         FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
         LikesInfo likesInfo = getLikesInfo(user.getId(), instance);
 
-        if (participantProvider.hasParticipant(user.getId(), instanceId)) {
+        if (participantProvider.hasJoinedParticipant(user.getId(), instanceId)) {
             return InstanceResponse.createByEntity(instance, likesInfo, JoinStatus.YES, fileResponse);
         }
 
@@ -90,7 +90,7 @@ public class InstanceDetailService {
     }
 
     private void validateInstanceCondition(User user, Instance instance) {
-        boolean isParticipated = participantProvider.hasParticipant(user.getId(), instance.getId());
+        boolean isParticipated = participantProvider.hasJoinedParticipant(user.getId(), instance.getId());
         if ((instance.getProgress() == Progress.PREACTIVITY) && !isParticipated) {
             return;
         }

--- a/src/main/java/com/genius/gitget/challenge/participant/service/ParticipantProvider.java
+++ b/src/main/java/com/genius/gitget/challenge/participant/service/ParticipantProvider.java
@@ -8,7 +8,6 @@ import com.genius.gitget.challenge.participant.domain.JoinStatus;
 import com.genius.gitget.challenge.participant.domain.Participant;
 import com.genius.gitget.challenge.participant.repository.ParticipantRepository;
 import com.genius.gitget.global.util.exception.BusinessException;
-import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,12 +64,9 @@ public class ParticipantProvider {
         return participantRepository.findAllJoinedByProgress(userId, progress);
     }
 
-    public boolean hasParticipant(Long userId, Long instanceId) {
-        return participantRepository.findByJoinInfo(userId, instanceId).isPresent();
+    public boolean hasJoinedParticipant(Long userId, Long instanceId) {
+        return participantRepository.findByJoinInfo(userId, instanceId)
+                .map(participant -> participant.getJoinStatus() != JoinStatus.NO)
+                .orElse(false);
     }
-
-    public LocalDate getInstanceStartDate(Long participantId) {
-        return getInstanceById(participantId).getStartedDate().toLocalDate();
-    }
-
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/211-instance-cancel-bug` → `main`

</br>

### 변경 사항
- [x] `ProfileService`의 `getUserChallengeResult()` 메서드의 가독성을 높이려는 시도를 해보았습니다.
    - [x]  일반적인 for문을 iterator로 변경했습니다. 
            AS-IS: `get(i)`를 통해 원소에 접근 가능
            TO-BE: `for (Participant participant : participantInfos)`에서 바로 participant를 통해 원소에 접근 가능
- [x] Instance 클래스 내에 참여자 수 갱신 메서드에서, 갱신된 값이 음수가 될 수 있는 경우에는 갱신시키지 않도록 처리
    - [x] `updateParticipantCount()`에서 음수가 될 수 있는 경우 0으로 설정하도록 처리
- [x] `ParticipantProvider`의 `hasJoinedParticipant()`에서 인스턴스 참여 여부 확인하는 로직 수정
    - [x] `JoinStatus`가 `No`일 때(실패 처리 = 실질적으로는 참여하고 있지 않을 때)에도 참여로 간주하고 있어, `No`일 때에는 false를 반환하도록 변경

</br>

### 테스트 결과
![image](https://github.com/TeamTheGenius/TeamTheGenius_Server/assets/50323157/30b9606d-5539-4326-bd0c-18900719a92b)


</br>

### 연관된 이슈
#211

</br>

### 리뷰 요구사항(선택)
> 코드의 가독성을 고려하면서 작성해봤는데, 보시고 어떤지 피드백 해주시면 좋을 것 같아요!! :)