### PR TITLE
[FIX] 실패한 챌린지 경우 마이챌린지의 완료 탭에 나타나지 않는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/myChallenge/service/MyChallengeService.java
+++ b/src/main/java/com/genius/gitget/challenge/myChallenge/service/MyChallengeService.java
@@ -71,7 +71,7 @@ public class MyChallengeService {
 
     public List<DoneResponse> getDoneInstances(User user, LocalDate targetDate) {
         List<DoneResponse> done = new ArrayList<>();
-        List<Participant> participants = participantProvider.findJoinedByProgress(user.getId(), Progress.DONE);
+        List<Participant> participants = participantProvider.findDoneInstances(user.getId());
 
         for (Participant participant : participants) {
             Instance instance = participant.getInstance();

--- a/src/main/java/com/genius/gitget/challenge/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/genius/gitget/challenge/participant/repository/ParticipantRepository.java
@@ -17,9 +17,10 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     Optional<Participant> findByJoinInfo(@Param("userId") Long userId,
                                          @Param("instanceId") Long instanceId);
 
-    @Query("select p from Participant p where p.user.id = :userId and p.instance.progress = :progress and p.joinStatus = 'YES'")
-    List<Participant> findAllJoinedByProgress(@Param("userId") Long userId,
-                                              @Param("progress") Progress progress);
+    @Query("select p from Participant p where p.user.id = :userId and p.instance.progress = :progress and p.joinStatus = :joinStatus")
+    List<Participant> findAllByStatus(@Param("userId") Long userId,
+                                      @Param("progress") Progress progress,
+                                      @Param("joinStatus") JoinStatus joinStatus);
 
     @Query("select p from Participant p where p.instance.id = :instanceId and p.joinStatus = :joinStatus")
     Slice<Participant> findAllByInstanceId(@Param("instanceId") Long instanceId,

--- a/src/main/java/com/genius/gitget/challenge/participant/service/ParticipantProvider.java
+++ b/src/main/java/com/genius/gitget/challenge/participant/service/ParticipantProvider.java
@@ -8,6 +8,7 @@ import com.genius.gitget.challenge.participant.domain.JoinStatus;
 import com.genius.gitget.challenge.participant.domain.Participant;
 import com.genius.gitget.challenge.participant.repository.ParticipantRepository;
 import com.genius.gitget.global.util.exception.BusinessException;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -61,7 +62,19 @@ public class ParticipantProvider {
     }
 
     public List<Participant> findJoinedByProgress(Long userId, Progress progress) {
-        return participantRepository.findAllJoinedByProgress(userId, progress);
+        return participantRepository.findAllByStatus(userId, progress, JoinStatus.YES);
+    }
+
+    public List<Participant> findDoneInstances(Long userId) {
+        List<Participant> doneInstances = new ArrayList<>();
+        // 실패한 챌린지 리스트
+        doneInstances.addAll(participantRepository.findAllByStatus(userId, Progress.ACTIVITY, JoinStatus.NO));
+        doneInstances.addAll(participantRepository.findAllByStatus(userId, Progress.DONE, JoinStatus.NO));
+
+        // 성공한 챌린지 리스트
+        doneInstances.addAll(participantRepository.findAllByStatus(userId, Progress.DONE, JoinStatus.YES));
+
+        return doneInstances;
     }
 
     public boolean hasJoinedParticipant(Long userId, Long instanceId) {

--- a/src/main/java/com/genius/gitget/challenge/participant/service/ParticipantProvider.java
+++ b/src/main/java/com/genius/gitget/challenge/participant/service/ParticipantProvider.java
@@ -69,7 +69,6 @@ public class ParticipantProvider {
         List<Participant> doneInstances = new ArrayList<>();
         // 실패한 챌린지 리스트
         doneInstances.addAll(participantRepository.findAllByStatus(userId, Progress.ACTIVITY, JoinStatus.NO));
-        doneInstances.addAll(participantRepository.findAllByStatus(userId, Progress.DONE, JoinStatus.NO));
 
         // 성공한 챌린지 리스트
         doneInstances.addAll(participantRepository.findAllByStatus(userId, Progress.DONE, JoinStatus.YES));


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가

□ 기능 삭제

☑ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/228-myChallange-done-list` → `main`

</br>

### 변경 사항
> 실패한 챌린지인 경우(도중 포기, 인증 달성율 도달 못함) `마이페이지`의 완료에는 카운트되지만, `마이챌린지`의 완료 탭에는 나타나지 않는 버그 픽스

- [x] 실패한 챌린지가 뜨지 않는 버그 픽스: 진행 도중인 챌린지를 도중 참여 취소할 경우 실패로 처리하는데, 해당 경우를 고려하지 않음.
    - [x] `ParticipantRepository`의  `findAllJoinedByProgress()`의 쿼리문에 JoinStatus 조건 추가
- [x]  테스트 코드: ACITIVITY 인스턴스 참여 취소 시, 실패 처리로 인해 마이 챌린지 - 완료 탭에 나오는지 확인하는 코드 작성

</br>

### 테스트 결과
![image](https://github.com/user-attachments/assets/12977dda-810b-4ac7-b150-aa5191d10f4d)


</br>

### 연관된 이슈
#228 

</br>

### 리뷰 요구사항(선택)

