### PR TITLE
[FIX] 실패한 챌린지에 대해 달성율이 나오지 않는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/myChallenge/dto/DoneResponse.java
+++ b/src/main/java/com/genius/gitget/challenge/myChallenge/dto/DoneResponse.java
@@ -40,7 +40,8 @@ public class DoneResponse extends ItemUseResponse {
 
     public static DoneResponse createNotRewarded(Instance instance,
                                                  Participant participant,
-                                                 int numOfPointItem, FileResponse fileResponse) {
+                                                 int numOfPointItem, double achievementRate,
+                                                 FileResponse fileResponse) {
         return DoneResponse.builder()
                 .title(instance.getTitle())
                 .instanceId(instance.getId())
@@ -48,6 +49,7 @@ public class DoneResponse extends ItemUseResponse {
                 .joinResult(participant.getJoinResult())
                 .canGetReward(canGetReward(participant))
                 .numOfPointItem(numOfPointItem)
+                .achievementRate(achievementRate)
                 .fileResponse(fileResponse)
                 .build();
     }

--- a/src/main/java/com/genius/gitget/challenge/myChallenge/service/MyChallengeService.java
+++ b/src/main/java/com/genius/gitget/challenge/myChallenge/service/MyChallengeService.java
@@ -76,20 +76,20 @@ public class MyChallengeService {
         for (Participant participant : participants) {
             Instance instance = participant.getInstance();
             FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+            double achievementRate = getAchievementRate(instance, participant.getId(), targetDate);
 
             // 포인트를 아직 수령하지 않았을 때
             if (participant.getRewardStatus() == NO) {
                 Item item = itemProvider.findAllByCategory(POINT_MULTIPLIER).get(0);
                 int numOfPassItem = ordersProvider.countNumOfItem(user, item.getId());
                 DoneResponse doneResponse = DoneResponse.createNotRewarded(
-                        instance, participant, numOfPassItem, fileResponse);
+                        instance, participant, numOfPassItem, achievementRate, fileResponse);
                 doneResponse.setItemId(item.getId());
                 done.add(doneResponse);
                 continue;
             }
 
             // 포인트를 수령했을 때
-            double achievementRate = getAchievementRate(instance, participant.getId(), targetDate);
             DoneResponse doneResponse = DoneResponse.createRewarded(
                     instance, participant, achievementRate, fileResponse);
             done.add(doneResponse);

--- a/src/test/java/com/genius/gitget/challenge/myChallenge/service/MyChallengeServiceTest.java
+++ b/src/test/java/com/genius/gitget/challenge/myChallenge/service/MyChallengeServiceTest.java
@@ -1,5 +1,6 @@
 package com.genius.gitget.challenge.myChallenge.service;
 
+import static com.genius.gitget.challenge.participant.domain.JoinResult.FAIL;
 import static com.genius.gitget.challenge.participant.domain.JoinResult.PROCESSING;
 import static com.genius.gitget.challenge.participant.domain.JoinResult.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,11 +12,6 @@ import com.genius.gitget.challenge.certification.util.DateUtil;
 import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.domain.Progress;
 import com.genius.gitget.challenge.instance.repository.InstanceRepository;
-import com.genius.gitget.store.item.domain.Item;
-import com.genius.gitget.store.item.domain.ItemCategory;
-import com.genius.gitget.store.item.domain.Orders;
-import com.genius.gitget.store.item.repository.ItemRepository;
-import com.genius.gitget.store.item.repository.OrdersRepository;
 import com.genius.gitget.challenge.myChallenge.dto.ActivatedResponse;
 import com.genius.gitget.challenge.myChallenge.dto.DoneResponse;
 import com.genius.gitget.challenge.myChallenge.dto.PreActivityResponse;
@@ -28,6 +24,11 @@ import com.genius.gitget.challenge.user.domain.Role;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.repository.UserRepository;
 import com.genius.gitget.global.security.constants.ProviderInfo;
+import com.genius.gitget.store.item.domain.Item;
+import com.genius.gitget.store.item.domain.ItemCategory;
+import com.genius.gitget.store.item.domain.Orders;
+import com.genius.gitget.store.item.repository.ItemRepository;
+import com.genius.gitget.store.item.repository.OrdersRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -180,6 +181,33 @@ class MyChallengeServiceTest {
         //then
         assertThat(doneResponses.size()).isEqualTo(1);
         assertThat(doneResponses.get(0).isCanGetReward()).isTrue();
+    }
+
+    @Test
+    @DisplayName("챌린지는 종료되었으나 실패한 챌린지에 대해, 정보를 전달해야 한다.")
+    public void should_returnInfo_when_failedChallenge() {
+        //given
+        LocalDate targetDate = LocalDate.of(2024, 2, 14);
+        User user = getSavedUser();
+        Instance instance = getSavedInstance(Progress.DONE);
+        getSavedParticipant(user, instance, FAIL);
+
+        //when
+        List<DoneResponse> doneInstances = myChallengeService.getDoneInstances(user, targetDate);
+        DoneResponse doneResponse = doneInstances.get(0);
+
+        //then
+        assertThat(doneInstances.size()).isEqualTo(1);
+
+        assertThat(doneResponse.getInstanceId()).isEqualTo(instance.getId());
+        assertThat(doneResponse.getTitle()).isEqualTo(instance.getTitle());
+        assertThat(doneResponse.getInstanceId()).isEqualTo(instance.getId());
+        assertThat(doneResponse.getRewardedPoints()).isZero();
+        assertThat(doneResponse.getJoinResult()).isEqualTo(FAIL);
+        assertThat(doneResponse.getFileResponse()).isNotNull();
+        assertThat(doneResponse.isCanGetReward()).isFalse();
+        assertThat(doneResponse.getAchievementRate()).isEqualTo(0.0);
+        assertThat(doneResponse.getNumOfPointItem()).isEqualTo(0);
     }
 
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/227-archivement-rate-bug` → `main`

</br>

### 변경 사항
- [x] 끝까지 참여는 했지만, 달성율이 목표치에 도달하지 않아 실패한 챌린지에 대해 달성율이 나오지 않는 버그 픽스
- [x] 응답 DTO에 해당 데이터 추가
- [x] 버그가 발생한 상황에 대해 테스트 코드 작성

</br>

### 테스트 결과
![image](https://github.com/user-attachments/assets/18d34d54-ecc1-4599-b288-3f05815be49f)


</br>

### 연관된 이슈
#227 

</br>

### 리뷰 요구사항(선택)
> 
