### PR TITLE
[REFACTOR] Files 서비스 계층 이름 변경

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/service/CertificationService.java
@@ -22,7 +22,7 @@ import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.dto.UserProfileInfo;
 import com.genius.gitget.challenge.user.service.UserService;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.util.exception.BusinessException;
 import com.genius.gitget.global.util.exception.ErrorCode;
 import java.time.LocalDate;
@@ -46,7 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CertificationService {
     private final UserService userService;
-    private final FilesService filesService;
+    private final FilesManager filesManager;
     private final GithubProvider githubProvider;
     private final CertificationProvider certificationProvider;
     private final ParticipantService participantService;
@@ -177,7 +177,7 @@ public class CertificationService {
                     return passed;
                 });
 
-        FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
         //TODO: pass 했기 때문에 pass item이 필요없어 numOfPassItem을 0으로 전달하는 것 같음. but, 가독성이 떨어지기 때문에 수정 필요
         return ActivatedResponse.of(instance, certification.getCertificationStatus(),
                 0, participant.getRepositoryName(), fileResponse);
@@ -247,7 +247,7 @@ public class CertificationService {
 
     public InstancePreviewResponse getInstancePreview(Long instanceId) {
         Instance instance = instanceProvider.findById(instanceId);
-        FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
         return InstancePreviewResponse.createByEntity(instance, fileResponse);
     }
 

--- a/src/main/java/com/genius/gitget/challenge/instance/facade/InstanceFacadeService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/facade/InstanceFacadeService.java
@@ -8,7 +8,7 @@ import com.genius.gitget.challenge.instance.dto.crud.InstanceUpdateDTO;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceUpdateRequest;
 import com.genius.gitget.challenge.instance.service.InstanceService;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Transactional
 public class InstanceFacadeService implements InstanceFacade {
-    private final FilesService filesService;
+    private final FilesManager filesManager;
     private final InstanceService instanceService;
 
     // 인스턴스 생성
@@ -56,7 +56,7 @@ public class InstanceFacadeService implements InstanceFacade {
     @Override
     public InstanceDetailResponse findOne(Long id) {
         Instance instance = instanceService.findInstanceById(id);
-        FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
 
         return InstanceDetailResponse.of(instance, fileResponse);
     }
@@ -75,7 +75,7 @@ public class InstanceFacadeService implements InstanceFacade {
     }
 
     private InstancePagingResponse mapToInstancePagingResponse(Instance instance) {
-        FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
         return InstancePagingResponse.of(instance, fileResponse);
     }
 }

--- a/src/main/java/com/genius/gitget/challenge/instance/facade/InstanceHomeFacadeService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/facade/InstanceHomeFacadeService.java
@@ -9,7 +9,7 @@ import com.genius.gitget.challenge.instance.service.InstanceRecommendationServic
 import com.genius.gitget.challenge.instance.service.InstanceSearchService;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +29,7 @@ public class InstanceHomeFacadeService implements InstanceHomeFacade {
 
     private final InstanceRecommendationService instanceRecommendationService;
     private final InstanceSearchService instanceSearchService;
-    private final FilesService filesService;
+    private final FilesManager filesManager;
 
     @Override
     public Page<InstanceSearchResponse> searchInstancesByKeywordAndProgress(InstanceSearchRequest instanceSearchRequest,
@@ -54,7 +54,7 @@ public class InstanceHomeFacadeService implements InstanceHomeFacade {
     }
 
     private InstanceSearchResponse convertToSearchResponse(Instance instance) {
-        FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
         return InstanceSearchResponse.builder()
                 .topicId(instance.getTopic().getId())
                 .instanceId(instance.getId())
@@ -72,7 +72,7 @@ public class InstanceHomeFacadeService implements InstanceHomeFacade {
     }
 
     private HomeInstanceResponse mapToHomeInstanceResponse(Instance instance) {
-        FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
         return HomeInstanceResponse.createByEntity(instance, fileResponse);
     }
 

--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceDetailService.java
@@ -18,7 +18,7 @@ import com.genius.gitget.challenge.participant.service.ParticipantService;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.service.UserService;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.util.exception.BusinessException;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -34,7 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class InstanceDetailService {
     private final UserService userService;
-    private final FilesService filesService;
+    private final FilesManager filesManager;
     private final InstanceProvider instanceProvider;
     private final ParticipantService participantService;
     private final GithubProvider githubProvider;
@@ -43,7 +43,7 @@ public class InstanceDetailService {
 
     public InstanceResponse getInstanceDetailInformation(User user, Long instanceId) {
         Instance instance = instanceProvider.findById(instanceId);
-        FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
         LikesInfo likesInfo = getLikesInfo(user.getId(), instance);
 
         if (participantService.hasJoinedParticipant(user.getId(), instanceId)) {

--- a/src/main/java/com/genius/gitget/challenge/instance/service/InstanceService.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/service/InstanceService.java
@@ -8,7 +8,7 @@ import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.dto.crud.InstanceUpdateDTO;
 import com.genius.gitget.challenge.instance.repository.InstanceRepository;
 import com.genius.gitget.global.file.domain.Files;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.util.exception.BusinessException;
 import com.genius.gitget.global.util.exception.ErrorCode;
 import com.genius.gitget.topic.domain.Topic;
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class InstanceService {
     private final InstanceRepository instanceRepository;
     private final TopicRepository topicRepository;
-    private final FilesService filesService;
+    private final FilesManager filesManager;
 
     @NotNull
     private String getUuid() {
@@ -82,7 +82,7 @@ public class InstanceService {
         Long filesId = files != null ? files.getId() : null;
 
         if (filesId != null) {
-            filesService.deleteFile(filesId);
+            filesManager.deleteFile(filesId);
             instance.setFiles(null);
         }
         instanceRepository.delete(instance);

--- a/src/main/java/com/genius/gitget/challenge/likes/facade/LikesFacadeService.java
+++ b/src/main/java/com/genius/gitget/challenge/likes/facade/LikesFacadeService.java
@@ -7,7 +7,7 @@ import com.genius.gitget.challenge.likes.dto.UserLikesResponse;
 import com.genius.gitget.challenge.likes.service.LikesService;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import java.util.LinkedList;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -19,11 +19,11 @@ import org.springframework.stereotype.Component;
 public class LikesFacadeService implements LikesFacade {
 
     LikesService likesService;
-    FilesService filesService;
+    FilesManager filesManager;
 
-    public LikesFacadeService(LikesService likesService, FilesService filesService) {
+    public LikesFacadeService(LikesService likesService, FilesManager filesManager) {
         this.likesService = likesService;
-        this.filesService = filesService;
+        this.filesManager = filesManager;
     }
 
     @Override
@@ -34,7 +34,7 @@ public class LikesFacadeService implements LikesFacade {
 
         for (Likes like : likesList) {
             Instance instance = like.getInstance();
-            FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+            FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
             UserLikesResponse userLikesResponse = getUserLikesResponse(like, instance, fileResponse);
             userLikesResponses.addFirst(userLikesResponse);
         }

--- a/src/main/java/com/genius/gitget/challenge/myChallenge/facade/MyChallengeFacadeService.java
+++ b/src/main/java/com/genius/gitget/challenge/myChallenge/facade/MyChallengeFacadeService.java
@@ -17,7 +17,7 @@ import com.genius.gitget.challenge.participant.domain.Participant;
 import com.genius.gitget.challenge.participant.service.ParticipantService;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.store.item.domain.Item;
 import com.genius.gitget.store.item.service.ItemService;
 import com.genius.gitget.store.item.service.OrdersService;
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MyChallengeFacadeService implements MyChallengeFacade {
-    private final FilesService filesService;
+    private final FilesManager filesManager;
     private final ParticipantService participantService;
     private final CertificationProvider certificationProvider;
     private final ItemService itemService;
@@ -46,7 +46,7 @@ public class MyChallengeFacadeService implements MyChallengeFacade {
 
         for (Participant participant : participants) {
             Instance instance = participant.getInstance();
-            FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+            FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
             int remainDays = DateUtil.getRemainDaysToStart(participant.getStartedDate(), targetDate);
 
             PreActivityResponse preActivityResponse = PreActivityResponse.of(instance, remainDays, fileResponse);
@@ -63,7 +63,7 @@ public class MyChallengeFacadeService implements MyChallengeFacade {
 
         for (Participant participant : participants) {
             Instance instance = participant.getInstance();
-            FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+            FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
             Certification certification = certificationProvider.findOrGetDummy(targetDate, participant.getId());
 
             Item item = itemService.findAllByCategory(CERTIFICATION_PASSER).get(0);
@@ -86,7 +86,7 @@ public class MyChallengeFacadeService implements MyChallengeFacade {
 
         for (Participant participant : participants) {
             Instance instance = participant.getInstance();
-            FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+            FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
             double achievementRate = certificationProvider.getAchievementRate(instance, participant.getId(),
                     targetDate);
 
@@ -118,7 +118,7 @@ public class MyChallengeFacadeService implements MyChallengeFacade {
         );
         Instance instance = participant.getInstance();
 
-        FileResponse fileResponse = filesService.convertToFileResponse(instance.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(instance.getFiles());
 
         int rewardPoints = instance.getPointPerPerson();
         participantService.getRewards(participant, rewardPoints);

--- a/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
+++ b/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
@@ -12,7 +12,7 @@ import com.genius.gitget.challenge.user.dto.SignupRequest;
 import com.genius.gitget.challenge.user.dto.UserProfileInfo;
 import com.genius.gitget.challenge.user.repository.UserRepository;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.security.dto.AuthResponse;
 import com.genius.gitget.global.util.exception.BusinessException;
 import com.genius.gitget.store.item.domain.Item;
@@ -31,7 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
     private final OrdersService ordersService;
-    private final FilesService filesService;
+    private final FilesManager filesManager;
     private final EncryptUtil encryptUtil;
 
     @Value("${admin.githubId}")
@@ -104,7 +104,7 @@ public class UserService {
 
     public UserProfileInfo getUserProfileInfo(User user) {
         Long frameId = ordersService.getUsingFrameItem(user.getId()).getId();
-        FileResponse fileResponse = filesService.convertToFileResponse(user.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(user.getFiles());
 
         return UserProfileInfo.createByEntity(user, frameId, fileResponse);
     }

--- a/src/main/java/com/genius/gitget/global/file/controller/FileTestController.java
+++ b/src/main/java/com/genius/gitget/global/file/controller/FileTestController.java
@@ -5,8 +5,8 @@ import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 import com.genius.gitget.global.file.domain.FileType;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FileManager;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FileService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import java.util.Optional;
@@ -29,16 +29,16 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/api/file/test")
 public class FileTestController {
-    private final FilesService filesService;
-    private final FileManager fileManager;
+    private final FilesManager filesManager;
+    private final FileService fileService;
 
 
     @GetMapping("/{fileId}")
     public ResponseEntity<SingleResponse<FileResponse>> download(
             @PathVariable Long fileId
     ) {
-        Files files = filesService.findById(fileId);
-        FileResponse fileResponse = filesService.convertToFileResponse(Optional.ofNullable(files));
+        Files files = filesManager.findById(fileId);
+        FileResponse fileResponse = filesManager.convertToFileResponse(Optional.ofNullable(files));
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), fileResponse)
@@ -51,8 +51,8 @@ public class FileTestController {
             @RequestParam("type") String type
     ) {
         FileType fileType = FileType.findType(type);
-        Files files = filesService.uploadFile(multipartFile, fileType);
-        String encodedImage = fileManager.getEncodedImage(files);
+        Files files = filesManager.uploadFile(multipartFile, fileType);
+        String encodedImage = fileService.getEncodedImage(files);
         FileResponse fileResponse = FileResponse.createExistFile(files.getId(), encodedImage);
 
         return ResponseEntity.ok().body(
@@ -64,8 +64,8 @@ public class FileTestController {
     public ResponseEntity<SingleResponse<FileResponse>> update(
             @PathVariable Long fileId,
             @RequestParam("files") MultipartFile multipartFile) {
-        Files files = filesService.updateFile(fileId, multipartFile);
-        String encodedImage = fileManager.getEncodedImage(files);
+        Files files = filesManager.updateFile(fileId, multipartFile);
+        String encodedImage = fileService.getEncodedImage(files);
         FileResponse fileResponse = FileResponse.createExistFile(files.getId(), encodedImage);
 
         return ResponseEntity.ok().body(
@@ -79,10 +79,10 @@ public class FileTestController {
             @RequestParam("type") String type) {
 
         FileType fileType = FileType.findType(type);
-        Files files = filesService.findById(fileId);
-        Files copiedFile = filesService.copyFile(files, fileType);
+        Files files = filesManager.findById(fileId);
+        Files copiedFile = filesManager.copyFile(files, fileType);
 
-        String encodedImage = fileManager.getEncodedImage(copiedFile);
+        String encodedImage = fileService.getEncodedImage(copiedFile);
         FileResponse fileResponse = FileResponse.createExistFile(copiedFile.getId(), encodedImage);
 
         return ResponseEntity.ok().body(
@@ -94,7 +94,7 @@ public class FileTestController {
     public ResponseEntity<CommonResponse> delete(
             @PathVariable Long fileId
     ) {
-        filesService.deleteFile(fileId);
+        filesManager.deleteFile(fileId);
 
         return ResponseEntity.ok().body(
                 new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage())

--- a/src/main/java/com/genius/gitget/global/file/controller/FilesController.java
+++ b/src/main/java/com/genius/gitget/global/file/controller/FilesController.java
@@ -7,7 +7,7 @@ import com.genius.gitget.global.file.domain.FileType;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.dto.FileResponse;
 import com.genius.gitget.global.file.service.FileHolderFinder;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/file")
 public class FilesController {
     private final FileHolderFinder finder;
-    private final FilesService filesService;
+    private final FilesManager filesManager;
 
 
     @PostMapping("/{id}")
@@ -40,8 +40,8 @@ public class FilesController {
         FileHolder fileHolder = finder.findByInfo(id, fileType);
         Files files;
 
-        files = filesService.uploadFile(fileHolder, multipartFile, fileType);
-        FileResponse fileResponse = filesService.convertToFileResponse(Optional.ofNullable(files));
+        files = filesManager.uploadFile(fileHolder, multipartFile, fileType);
+        FileResponse fileResponse = filesManager.convertToFileResponse(Optional.ofNullable(files));
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), fileResponse)
@@ -56,8 +56,8 @@ public class FilesController {
     ) {
         FileType fileType = FileType.findType(type);
         FileHolder fileHolder = finder.findByInfo(id, fileType);
-        Files files = filesService.updateFile(fileHolder.getFiles(), multipartFile);
-        FileResponse fileResponse = filesService.convertToFileResponse(Optional.ofNullable(files));
+        Files files = filesManager.updateFile(fileHolder.getFiles(), multipartFile);
+        FileResponse fileResponse = filesManager.convertToFileResponse(Optional.ofNullable(files));
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), fileResponse)

--- a/src/main/java/com/genius/gitget/global/file/service/FileService.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FileService.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional(readOnly = true)
-public interface FileManager {
+public interface FileService {
 
     /**
      * Files 내에 저장된 값들을 통해 UrlResource 등으로 다운받은 후, base64로 인코딩한 결과 반환

--- a/src/main/java/com/genius/gitget/global/file/service/FilesManager.java
+++ b/src/main/java/com/genius/gitget/global/file/service/FilesManager.java
@@ -22,14 +22,14 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class FilesService {
-    private final FileManager fileManager;
+public class FilesManager {
+    private final FileService fileService;
     private final FilesRepository filesRepository;
 
 
     @Transactional
     public Files uploadFile(MultipartFile multipartFile, FileType fileType) {
-        FileDTO fileDTO = fileManager.upload(multipartFile, fileType);
+        FileDTO fileDTO = fileService.upload(multipartFile, fileType);
 
         Files file = Files.builder()
                 .originalFilename(fileDTO.originalFilename())
@@ -45,7 +45,7 @@ public class FilesService {
         if (multipartFile == null) {
             throw new BusinessException(MULTIPART_FILE_NOT_EXIST);
         }
-        FileDTO fileDTO = fileManager.upload(multipartFile, fileType);
+        FileDTO fileDTO = fileService.upload(multipartFile, fileType);
 
         Files file = Files.builder()
                 .originalFilename(fileDTO.originalFilename())
@@ -59,7 +59,7 @@ public class FilesService {
 
     @Transactional
     public Files copyFile(Files files, FileType fileType) {
-        FileDTO fileDTO = fileManager.copy(files, fileType);
+        FileDTO fileDTO = fileService.copy(files, fileType);
 
         Files copyFiles = Files.create(fileDTO);
         return filesRepository.save(copyFiles);
@@ -74,7 +74,7 @@ public class FilesService {
             return files;
         }
 
-        UpdateDTO updateDTO = fileManager.update(files, multipartFile);
+        UpdateDTO updateDTO = fileService.update(files, multipartFile);
         files.updateFiles(updateDTO);
         return files;
     }
@@ -86,7 +86,7 @@ public class FilesService {
             return files;
         }
 
-        UpdateDTO updateDTO = fileManager.update(files, multipartFile);
+        UpdateDTO updateDTO = fileService.update(files, multipartFile);
         files.updateFiles(updateDTO);
         return files;
     }
@@ -101,7 +101,7 @@ public class FilesService {
         Files files = filesRepository.findById(fileId)
                 .orElseThrow(() -> new BusinessException(FILE_NOT_EXIST));
 
-        fileManager.deleteInStorage(files);
+        fileService.deleteInStorage(files);
         filesRepository.delete(files);
     }
 
@@ -112,7 +112,7 @@ public class FilesService {
         }
         Files files = optionalFiles.get();
 
-        fileManager.deleteInStorage(files);
+        fileService.deleteInStorage(files);
         filesRepository.delete(files);
     }
 
@@ -124,7 +124,7 @@ public class FilesService {
     public FileResponse convertToFileResponse(Optional<Files> optionalFiles) {
         return optionalFiles
                 .map(files -> {
-                    String encodedImage = fileManager.getEncodedImage(files);
+                    String encodedImage = fileService.getEncodedImage(files);
                     return FileResponse.createExistFile(files.getId(), encodedImage);
                 })
                 .orElseGet(FileResponse::createNotExistFile);

--- a/src/main/java/com/genius/gitget/global/file/service/LocalFileService.java
+++ b/src/main/java/com/genius/gitget/global/file/service/LocalFileService.java
@@ -20,12 +20,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.UrlResource;
 import org.springframework.web.multipart.MultipartFile;
 
-public class LocalFileManager implements FileManager {
+public class LocalFileService implements FileService {
     private final String UPLOAD_PATH;
     private final FileUtil fileUtil;
 
 
-    public LocalFileManager(FileUtil fileUtil, @Value("${file.upload.path}") String UPLOAD_PATH) {
+    public LocalFileService(FileUtil fileUtil, @Value("${file.upload.path}") String UPLOAD_PATH) {
         this.fileUtil = fileUtil;
         this.UPLOAD_PATH = UPLOAD_PATH;
     }

--- a/src/main/java/com/genius/gitget/global/file/service/S3FileService.java
+++ b/src/main/java/com/genius/gitget/global/file/service/S3FileService.java
@@ -18,12 +18,12 @@ import java.util.Base64;
 import org.springframework.core.io.UrlResource;
 import org.springframework.web.multipart.MultipartFile;
 
-public class S3FileManager implements FileManager {
+public class S3FileService implements FileService {
     private final AmazonS3 amazonS3;
     private final FileUtil fileUtil;
     private final String bucket;
 
-    public S3FileManager(AmazonS3 amazonS3, FileUtil fileUtil, String bucket) {
+    public S3FileService(AmazonS3 amazonS3, FileUtil fileUtil, String bucket) {
         this.amazonS3 = amazonS3;
         this.fileUtil = fileUtil;
         this.bucket = bucket;
@@ -61,7 +61,7 @@ public class S3FileManager implements FileManager {
     @Override
     public FileDTO copy(Files files, FileType fileType) {
         validateFileExist(files);
-        
+
         CopyDTO copyDTO = fileUtil.getCopyInfo(files, fileType, "");
 
         CopyObjectRequest copyObjectRequest = new CopyObjectRequest(

--- a/src/main/java/com/genius/gitget/global/util/config/AppConfig.java
+++ b/src/main/java/com/genius/gitget/global/util/config/AppConfig.java
@@ -1,9 +1,9 @@
 package com.genius.gitget.global.util.config;
 
-import com.genius.gitget.global.file.service.FileManager;
+import com.genius.gitget.global.file.service.FileService;
 import com.genius.gitget.global.file.service.FileUtil;
-import com.genius.gitget.global.file.service.LocalFileManager;
-import com.genius.gitget.global.file.service.S3FileManager;
+import com.genius.gitget.global.file.service.LocalFileService;
+import com.genius.gitget.global.file.service.S3FileService;
 import com.genius.gitget.global.util.formatter.LocalDateFormatter;
 import com.genius.gitget.global.util.formatter.LocalDateTimeFormatter;
 import lombok.RequiredArgsConstructor;
@@ -25,17 +25,17 @@ public class AppConfig {
     }
 
     @Bean
-    public FileManager fileManager() {
+    public FileService fileManager() {
         final String fileMode = env.getProperty("file.mode");
         assert fileMode != null;
 
         if (fileMode.equals("local")) {
             final String UPLOAD_PATH = env.getProperty("file.upload.path");
-            return new LocalFileManager(fileUtil(), UPLOAD_PATH);
+            return new LocalFileService(fileUtil(), UPLOAD_PATH);
         }
 
         final String bucket = env.getProperty("cloud.aws.s3.bucket");
-        return new S3FileManager(s3Config.amazonS3Client(), fileUtil(), bucket);
+        return new S3FileService(s3Config.amazonS3Client(), fileUtil(), bucket);
     }
 
     @Bean

--- a/src/main/java/com/genius/gitget/profile/service/ProfileService.java
+++ b/src/main/java/com/genius/gitget/profile/service/ProfileService.java
@@ -11,7 +11,7 @@ import com.genius.gitget.challenge.participant.domain.Participant;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.repository.UserRepository;
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.util.exception.BusinessException;
 import com.genius.gitget.global.util.exception.ErrorCode;
 import com.genius.gitget.profile.dto.UserChallengeResultResponse;
@@ -39,7 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ProfileService {
     private final UserRepository userRepository;
-    private final FilesService filesService;
+    private final FilesManager filesManager;
     private final SignoutRepository signoutRepository;
     private final OrdersService ordersService;
 
@@ -56,7 +56,7 @@ public class ProfileService {
         User findUser = getUserById(userId);
         Long frameId = ordersService.getUsingFrameItem(userId).getId();
 
-        FileResponse fileResponse = filesService.convertToFileResponse(findUser.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(findUser.getFiles());
         return UserInformationResponse.createByEntity(findUser, frameId, fileResponse);
     }
 
@@ -72,7 +72,7 @@ public class ProfileService {
                 participantCount = (joinResult == SUCCESS) ? participantCount + 1 : participantCount - 1;
             }
         }
-        FileResponse fileResponse = filesService.convertToFileResponse(findUser.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(findUser.getFiles());
         return UserDetailsInformationResponse.createByEntity(findUser, participantCount, fileResponse);
     }
 
@@ -93,7 +93,7 @@ public class ProfileService {
     public void deleteUserInformation(User user, String reason) {
         User findUser = getUserByIdentifier(user.getIdentifier());
 
-        filesService.deleteFile(findUser.getFiles());
+        filesManager.deleteFile(findUser.getFiles());
         findUser.setFiles(null);
 
         findUser.deleteLikesList();

--- a/src/main/java/com/genius/gitget/topic/facade/TopicFacadeService.java
+++ b/src/main/java/com/genius/gitget/topic/facade/TopicFacadeService.java
@@ -1,7 +1,7 @@
 package com.genius.gitget.topic.facade;
 
 import com.genius.gitget.global.file.dto.FileResponse;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.topic.domain.Topic;
 import com.genius.gitget.topic.dto.TopicCreateRequest;
 import com.genius.gitget.topic.dto.TopicDetailResponse;
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class TopicFacadeService implements TopicFacade {
 
-    private final FilesService filesService;
+    private final FilesManager filesManager;
     private final TopicService topicService;
 
 
@@ -32,7 +32,7 @@ public class TopicFacadeService implements TopicFacade {
     @Override
     public TopicDetailResponse findOne(Long id) {
         Topic findTopic = topicService.findOne(id);
-        FileResponse fileResponse = filesService.convertToFileResponse(findTopic.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(findTopic.getFiles());
         return TopicDetailResponse.of(findTopic, fileResponse);
     }
 
@@ -62,7 +62,7 @@ public class TopicFacadeService implements TopicFacade {
     }
 
     private TopicPagingResponse convertToTopicPagingResponseDto(Topic topic) {
-        FileResponse fileResponse = filesService.convertToFileResponse(topic.getFiles());
+        FileResponse fileResponse = filesManager.convertToFileResponse(topic.getFiles());
         return TopicPagingResponse.of(topic, fileResponse);
     }
 }

--- a/src/test/java/com/genius/gitget/challenge/instance/controller/InstanceControllerTest.java
+++ b/src/test/java/com/genius/gitget/challenge/instance/controller/InstanceControllerTest.java
@@ -12,7 +12,7 @@ import com.genius.gitget.challenge.instance.domain.Instance;
 import com.genius.gitget.challenge.instance.domain.Progress;
 import com.genius.gitget.challenge.instance.repository.InstanceRepository;
 import com.genius.gitget.challenge.user.domain.Role;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.topic.domain.Topic;
 import com.genius.gitget.topic.repository.TopicRepository;
 import com.genius.gitget.util.security.TokenTestUtil;
@@ -44,7 +44,7 @@ public class InstanceControllerTest {
     @Autowired
     InstanceRepository instanceRepository;
     @Autowired
-    FilesService filesService;
+    FilesManager filesManager;
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/com/genius/gitget/challenge/instance/service/InstanceFacadeTest.java
+++ b/src/test/java/com/genius/gitget/challenge/instance/service/InstanceFacadeTest.java
@@ -16,7 +16,7 @@ import com.genius.gitget.challenge.instance.util.TestSetup;
 import com.genius.gitget.global.file.domain.FileType;
 import com.genius.gitget.global.file.domain.Files;
 import com.genius.gitget.global.file.repository.FilesRepository;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.util.exception.BusinessException;
 import com.genius.gitget.topic.domain.Topic;
 import com.genius.gitget.topic.repository.TopicRepository;
@@ -45,7 +45,7 @@ public class InstanceFacadeTest {
     @Autowired
     TopicRepository topicRepository;
     @Autowired
-    FilesService filesService;
+    FilesManager filesManager;
     @Autowired
     FilesRepository filesRepository;
     @Autowired

--- a/src/test/java/com/genius/gitget/challenge/likes/controller/LikesControllerTest.java
+++ b/src/test/java/com/genius/gitget/challenge/likes/controller/LikesControllerTest.java
@@ -19,7 +19,7 @@ import com.genius.gitget.challenge.likes.service.LikesService;
 import com.genius.gitget.challenge.user.domain.Role;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.repository.UserRepository;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.security.constants.ProviderInfo;
 import com.genius.gitget.topic.domain.Topic;
 import com.genius.gitget.topic.repository.TopicRepository;
@@ -54,7 +54,7 @@ public class LikesControllerTest {
     @Autowired
     InstanceRepository instanceRepository;
     @Autowired
-    FilesService filesService;
+    FilesManager filesManager;
     @Autowired
     LikesService likesService;
     @Autowired

--- a/src/test/java/com/genius/gitget/global/file/service/FileUtilTest.java
+++ b/src/test/java/com/genius/gitget/global/file/service/FileUtilTest.java
@@ -33,7 +33,7 @@ class FileUtilTest {
     @Autowired
     private FileUtil fileUtil;
     @Autowired
-    private FilesService filesService;
+    private FilesManager filesManager;
     @Value("${file.upload.path}")
     private String UPLOAD_PATH;
 

--- a/src/test/java/com/genius/gitget/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/genius/gitget/payment/controller/PaymentControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.topic.repository.TopicRepository;
 import com.genius.gitget.util.security.TokenTestUtil;
 import com.genius.gitget.util.security.WithMockCustomUser;
@@ -38,7 +38,7 @@ public class PaymentControllerTest {
     @Autowired
     TopicRepository topicRepository;
     @Autowired
-    FilesService filesService;
+    FilesManager filesManager;
     @Autowired
     private ObjectMapper objectMapper;
 

--- a/src/test/java/com/genius/gitget/profile/controller/ProfileControllerTest.java
+++ b/src/test/java/com/genius/gitget/profile/controller/ProfileControllerTest.java
@@ -17,7 +17,7 @@ import com.genius.gitget.challenge.participant.repository.ParticipantRepository;
 import com.genius.gitget.challenge.user.domain.Role;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.repository.UserRepository;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.global.security.constants.ProviderInfo;
 import com.genius.gitget.topic.domain.Topic;
 import com.genius.gitget.topic.repository.TopicRepository;
@@ -57,7 +57,7 @@ public class ProfileControllerTest {
     @Autowired
     InstanceRepository instanceRepository;
     @Autowired
-    FilesService filesService;
+    FilesManager filesManager;
     @Autowired
     LikesService likesService;
     @Autowired

--- a/src/test/java/com/genius/gitget/topic/controller/TopicControllerTest.java
+++ b/src/test/java/com/genius/gitget/topic/controller/TopicControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.genius.gitget.challenge.user.domain.Role;
-import com.genius.gitget.global.file.service.FilesService;
+import com.genius.gitget.global.file.service.FilesManager;
 import com.genius.gitget.topic.domain.Topic;
 import com.genius.gitget.topic.repository.TopicRepository;
 import com.genius.gitget.util.security.TokenTestUtil;
@@ -38,7 +38,7 @@ public class TopicControllerTest {
     @Autowired
     TopicRepository topicRepository;
     @Autowired
-    FilesService filesService;
+    FilesManager filesManager;
     @Autowired
     private ObjectMapper objectMapper;
 


### PR DESCRIPTION


### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가
□ 기능 삭제
☑ 리팩토링
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`refactor/237-files-layer-name` → `main`

</br>

### 변경 사항
- [x] 파사드 패턴 적용으로 인해 FilesService와 FileManager의 이름을 서로 변경

</br>

### 테스트 결과
![image](https://github.com/user-attachments/assets/8ea335f3-7864-4742-9732-6d2ed80bcef4)


</br>

### 연관된 이슈
#237 

</br>

### 리뷰 요구사항(선택)
> 
