### PR TITLE
[FEAT] JWT 발급 API에서 header 추가 설정

### DIFF
--- a/src/main/java/com/genius/gitget/global/security/controller/AuthController.java
+++ b/src/main/java/com/genius/gitget/global/security/controller/AuthController.java
@@ -41,6 +41,7 @@ public class AuthController {
 
         jwtFacade.generateAccessToken(response, user);
         jwtFacade.generateRefreshToken(response, user);
+        jwtFacade.setReissuedHeader(response);
 
         AuthResponse authResponse = userService.getUserAuthInfo(user.getIdentifier());
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가

□ 기능 삭제

□ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/249-jwt-api-set-header` → `main`

</br>

### 변경 사항
- [x] JWT 발급 API(`POST /api/auth`)에서 token-reissued 값을 true로 설정하여 전달하도록 변경

</br>

### 테스트 결과
![image](https://github.com/user-attachments/assets/8bf5b0dc-789c-4933-baa9-5bf69c2281e4)


</br>

### 연관된 이슈
#249 

</br>

### 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
