### PR TITLE
[FEAT] Spring security 관련 커스텀 어노테이션 생성 및 적용

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/controller/CertificationController.java
@@ -17,7 +17,7 @@ import com.genius.gitget.challenge.participant.domain.Participant;
 import com.genius.gitget.challenge.participant.service.ParticipantService;
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.service.UserService;
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import com.genius.gitget.global.util.response.dto.SlicingResponse;
 import java.time.LocalDate;
@@ -28,7 +28,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -61,11 +60,11 @@ public class CertificationController {
 
     @PostMapping("/today")
     public ResponseEntity<SingleResponse<CertificationResponse>> certificateByGithub(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestBody CertificationRequest certificationRequest
     ) {
         CertificationResponse certificationResponse = certificationFacade.updateCertification(
-                userPrincipal.getUser(), certificationRequest);
+                user, certificationRequest);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), certificationResponse)
@@ -74,10 +73,9 @@ public class CertificationController {
 
     @PostMapping("/pass")
     public ResponseEntity<SingleResponse<ActivatedResponse>> passCertification(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestBody CertificationRequest certificationRequest
     ) {
-        User user = userPrincipal.getUser();
         ActivatedResponse activatedResponse = certificationFacade.passCertification(
                 user.getId(), certificationRequest);
 
@@ -88,11 +86,11 @@ public class CertificationController {
 
     @GetMapping("/week/{instanceId}")
     public ResponseEntity<SingleResponse<WeekResponse>> getWeekCertification(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable Long instanceId
     ) {
         LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
-        Participant participant = participantService.findByJoinInfo(userPrincipal.getUser().getId(), instanceId);
+        Participant participant = participantService.findByJoinInfo(user.getId(), instanceId);
         WeekResponse weekResponse = certificationFacade.getMyWeekCertifications(participant.getId(), kstDate);
 
         return ResponseEntity.ok().body(
@@ -102,12 +100,11 @@ public class CertificationController {
 
     @GetMapping("/week/all/{instanceId}")
     public ResponseEntity<SlicingResponse<WeekResponse>> getAllUserWeekCertification(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable Long instanceId,
             @PageableDefault Pageable pageable
     ) {
         LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
-        User user = userPrincipal.getUser();
         Slice<WeekResponse> certifications = certificationFacade.getOthersWeekCertifications(
                 user.getId(), instanceId, kstDate, pageable);
 
@@ -134,15 +131,13 @@ public class CertificationController {
 
     @GetMapping("/information/{instanceId}")
     public ResponseEntity<SingleResponse<CertificationInformation>> getCertificationInformation(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable Long instanceId
     ) {
 
         LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
         Instance instance = instanceService.findInstanceById(instanceId);
-        Participant participant = participantService.findByJoinInfo(
-                userPrincipal.getUser().getId(),
-                instanceId);
+        Participant participant = participantService.findByJoinInfo(user.getId(), instanceId);
 
         CertificationInformation certificationInformation = certificationFacade.getCertificationInformation(
                 instance, participant, kstDate);

--- a/src/main/java/com/genius/gitget/challenge/certification/controller/GithubController.java
+++ b/src/main/java/com/genius/gitget/challenge/certification/controller/GithubController.java
@@ -6,7 +6,8 @@ import com.genius.gitget.challenge.certification.dto.github.GithubTokenRequest;
 import com.genius.gitget.challenge.certification.dto.github.PullRequestResponse;
 import com.genius.gitget.challenge.certification.facade.GithubFacade;
 import com.genius.gitget.challenge.certification.util.DateUtil;
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.ListResponse;
 import java.time.LocalDateTime;
@@ -14,7 +15,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,10 +31,10 @@ public class GithubController {
 
     @PostMapping("/register/token")
     public ResponseEntity<CommonResponse> registerGithubToken(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestBody GithubTokenRequest githubTokenRequest
     ) {
-        githubFacade.registerGithubPersonalToken(userPrincipal.getUser(), githubTokenRequest.githubToken());
+        githubFacade.registerGithubPersonalToken(user, githubTokenRequest.githubToken());
 
         return ResponseEntity.ok().body(
                 new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage())
@@ -43,9 +43,9 @@ public class GithubController {
 
     @GetMapping("/repositories")
     public ResponseEntity<ListResponse<String>> getPublicRepositories(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
+            @GitGetUser User user
     ) {
-        List<String> repositories = githubFacade.getPublicRepositories(userPrincipal.getUser());
+        List<String> repositories = githubFacade.getPublicRepositories(user);
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), repositories)
@@ -54,9 +54,9 @@ public class GithubController {
 
     @GetMapping("/verify/token")
     public ResponseEntity<CommonResponse> verifyGithubToken(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
+            @GitGetUser User user
     ) {
-        githubFacade.verifyGithubToken(userPrincipal.getUser());
+        githubFacade.verifyGithubToken(user);
 
         return ResponseEntity.ok().body(
                 new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage())
@@ -65,11 +65,11 @@ public class GithubController {
 
     @GetMapping("/verify/repository")
     public ResponseEntity<CommonResponse> verifyRepository(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestParam String repo
     ) {
 
-        githubFacade.verifyRepository(userPrincipal.getUser(), repo);
+        githubFacade.verifyRepository(user, repo);
 
         return ResponseEntity.ok().body(
                 new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage())
@@ -78,12 +78,12 @@ public class GithubController {
 
     @GetMapping("/verify/pull-request")
     public ResponseEntity<ListResponse<PullRequestResponse>> verifyPullRequest(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestParam String repo
     ) {
 
         List<PullRequestResponse> pullRequestResponses = githubFacade.verifyPullRequest(
-                userPrincipal.getUser(), repo, DateUtil.convertToKST(LocalDateTime.now())
+                user, repo, DateUtil.convertToKST(LocalDateTime.now())
         );
 
         return ResponseEntity.ok().body(

--- a/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceDetailController.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceDetailController.java
@@ -9,14 +9,14 @@ import com.genius.gitget.challenge.instance.dto.detail.InstanceResponse;
 import com.genius.gitget.challenge.instance.dto.detail.JoinRequest;
 import com.genius.gitget.challenge.instance.dto.detail.JoinResponse;
 import com.genius.gitget.challenge.instance.service.InstanceDetailFacade;
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,11 +35,11 @@ public class InstanceDetailController {
 
     @GetMapping("/{instanceId}")
     public ResponseEntity<SingleResponse<InstanceResponse>> getInstanceDetail(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable Long instanceId
     ) {
         InstanceResponse instanceDetailInformation = instanceDetailFacade.getInstanceDetailInformation(
-                userPrincipal.getUser(), instanceId);
+                user, instanceId);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), instanceDetailInformation)
@@ -48,7 +48,7 @@ public class InstanceDetailController {
 
     @PostMapping("/{instanceId}")
     public ResponseEntity<SingleResponse<JoinResponse>> joinChallenge(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable Long instanceId,
             @RequestParam String repo
     ) {
@@ -58,7 +58,7 @@ public class InstanceDetailController {
                 .repository(repo)
                 .todayDate(kstDate)
                 .build();
-        JoinResponse joinResponse = instanceDetailFacade.joinNewChallenge(userPrincipal.getUser(), joinRequest);
+        JoinResponse joinResponse = instanceDetailFacade.joinNewChallenge(user, joinRequest);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(JOIN_SUCCESS.getStatus(), JOIN_SUCCESS.getMessage(), joinResponse)
@@ -67,10 +67,10 @@ public class InstanceDetailController {
 
     @DeleteMapping("/{instanceId}")
     public ResponseEntity<SingleResponse<JoinResponse>> quitChallenge(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable Long instanceId
     ) {
-        JoinResponse joinResponse = instanceDetailFacade.quitChallenge(userPrincipal.getUser(), instanceId);
+        JoinResponse joinResponse = instanceDetailFacade.quitChallenge(user, instanceId);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(QUIT_SUCCESS.getStatus(), QUIT_SUCCESS.getMessage(), joinResponse)

--- a/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceHomeController.java
+++ b/src/main/java/com/genius/gitget/challenge/instance/controller/InstanceHomeController.java
@@ -6,7 +6,8 @@ import com.genius.gitget.challenge.instance.dto.home.HomeInstanceResponse;
 import com.genius.gitget.challenge.instance.dto.search.InstanceSearchRequest;
 import com.genius.gitget.challenge.instance.dto.search.InstanceSearchResponse;
 import com.genius.gitget.challenge.instance.facade.InstanceHomeFacade;
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.exception.SuccessCode;
 import com.genius.gitget.global.util.response.dto.PagingResponse;
 import com.genius.gitget.global.util.response.dto.SlicingResponse;
@@ -18,7 +19,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,13 +46,13 @@ public class InstanceHomeController {
     @GetMapping("/recommend")
     public ResponseEntity<SlicingResponse<HomeInstanceResponse>> getRecommendInstances(
             Pageable pageable,
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+            @GitGetUser User user) {
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
                 Sort.by(Direction.DESC, "participantCount"));
 
         Slice<HomeInstanceResponse> recommendations = instanceHomeFacade.recommendInstances(
-                userPrincipal.getUser(), pageRequest);
+                user, pageRequest);
         return ResponseEntity.ok().body(
                 new SlicingResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), recommendations)
         );

--- a/src/main/java/com/genius/gitget/challenge/likes/controller/LikesController.java
+++ b/src/main/java/com/genius/gitget/challenge/likes/controller/LikesController.java
@@ -4,7 +4,8 @@ import com.genius.gitget.challenge.likes.dto.UserLikesAddRequest;
 import com.genius.gitget.challenge.likes.dto.UserLikesAddResponse;
 import com.genius.gitget.challenge.likes.dto.UserLikesResponse;
 import com.genius.gitget.challenge.likes.facade.LikesFacade;
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.exception.SuccessCode;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.PagingResponse;
@@ -15,7 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,10 +35,10 @@ public class LikesController {
     @GetMapping("/likes")
     public ResponseEntity<PagingResponse<UserLikesResponse>> getLikesListOfUser(
             Pageable pageable,
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+            @GitGetUser User user) {
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        Page<UserLikesResponse> likesResponses = likesFacade.getLikesList(userPrincipal.getUser(), pageRequest);
+        Page<UserLikesResponse> likesResponses = likesFacade.getLikesList(user, pageRequest);
 
         return ResponseEntity.ok().body(
                 new PagingResponse<>(SuccessCode.SUCCESS.getStatus(), SuccessCode.SUCCESS.getMessage(), likesResponses)
@@ -48,9 +48,9 @@ public class LikesController {
     // 좋아요 목록 추가
     @PostMapping("/likes")
     public ResponseEntity<SingleResponse<UserLikesAddResponse>> addLikes(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestBody UserLikesAddRequest userLikesAddRequest) {
-        UserLikesAddResponse userLikesAddResponse = likesFacade.addLikes(userPrincipal.getUser(),
+        UserLikesAddResponse userLikesAddResponse = likesFacade.addLikes(user,
                 userLikesAddRequest.getIdentifier(),
                 userLikesAddRequest.getInstanceId());
         return ResponseEntity.ok().body(
@@ -61,9 +61,9 @@ public class LikesController {
 
     // 좋아요 목록 삭제
     @DeleteMapping("/likes/{likesId}")
-    public ResponseEntity<CommonResponse> deleteLikes(@AuthenticationPrincipal UserPrincipal userPrincipal,
+    public ResponseEntity<CommonResponse> deleteLikes(@GitGetUser User user,
                                                       @PathVariable(value = "likesId") Long likesId) {
-        likesFacade.deleteLikes(userPrincipal.getUser(), likesId);
+        likesFacade.deleteLikes(user, likesId);
         return ResponseEntity.ok().body(
                 new CommonResponse(SuccessCode.SUCCESS.getStatus(), SuccessCode.SUCCESS.getMessage())
         );

--- a/src/main/java/com/genius/gitget/challenge/myChallenge/controller/MyChallengeController.java
+++ b/src/main/java/com/genius/gitget/challenge/myChallenge/controller/MyChallengeController.java
@@ -8,7 +8,8 @@ import com.genius.gitget.challenge.myChallenge.dto.DoneResponse;
 import com.genius.gitget.challenge.myChallenge.dto.PreActivityResponse;
 import com.genius.gitget.challenge.myChallenge.dto.RewardRequest;
 import com.genius.gitget.challenge.myChallenge.facade.MyChallengeFacade;
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.response.dto.ListResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import java.time.LocalDate;
@@ -16,7 +17,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,11 +32,10 @@ public class MyChallengeController {
 
     @GetMapping("/my/pre-activity")
     public ResponseEntity<ListResponse<PreActivityResponse>> getPreActivityChallenges(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
+            @GitGetUser User user
     ) {
         List<PreActivityResponse> preActivityInstances = myChallengeFacade.getPreActivityInstances(
-                userPrincipal.getUser(),
-                DateUtil.convertToKST(LocalDateTime.now()));
+                user, DateUtil.convertToKST(LocalDateTime.now()));
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), preActivityInstances)
@@ -46,11 +45,10 @@ public class MyChallengeController {
 
     @GetMapping("/my/activity")
     public ResponseEntity<ListResponse<ActivatedResponse>> getActivatedChallenges(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
+            @GitGetUser User user
     ) {
         List<ActivatedResponse> activatedInstances = myChallengeFacade.getActivatedInstances(
-                userPrincipal.getUser(),
-                DateUtil.convertToKST(LocalDateTime.now()));
+                user, DateUtil.convertToKST(LocalDateTime.now()));
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), activatedInstances)
@@ -59,11 +57,10 @@ public class MyChallengeController {
 
     @GetMapping("/my/done")
     public ResponseEntity<ListResponse<DoneResponse>> getDoneChallenges(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
+            @GitGetUser User user
     ) {
         List<DoneResponse> doneInstances = myChallengeFacade.getDoneInstances(
-                userPrincipal.getUser(),
-                DateUtil.convertToKST(LocalDateTime.now()));
+                user, DateUtil.convertToKST(LocalDateTime.now()));
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), doneInstances)
@@ -72,11 +69,11 @@ public class MyChallengeController {
 
     @GetMapping("/reward/{instanceId}")
     public ResponseEntity<SingleResponse<DoneResponse>> getRewards(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable Long instanceId
     ) {
         LocalDate kstDate = DateUtil.convertToKST(LocalDateTime.now());
-        RewardRequest rewardRequest = new RewardRequest(userPrincipal.getUser().getId(), instanceId, kstDate);
+        RewardRequest rewardRequest = new RewardRequest(user.getId(), instanceId, kstDate);
         DoneResponse doneResponse = myChallengeFacade.getRewards(rewardRequest);
 
         return ResponseEntity.ok().body(

--- a/src/main/java/com/genius/gitget/global/security/controller/AuthController.java
+++ b/src/main/java/com/genius/gitget/global/security/controller/AuthController.java
@@ -5,10 +5,10 @@ import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
 import com.genius.gitget.challenge.user.domain.User;
 import com.genius.gitget.challenge.user.service.UserService;
-import com.genius.gitget.global.security.domain.UserPrincipal;
 import com.genius.gitget.global.security.dto.AuthResponse;
 import com.genius.gitget.global.security.dto.TokenRequest;
 import com.genius.gitget.global.security.service.JwtFacade;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.exception.BusinessException;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
@@ -16,7 +16,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -51,10 +50,8 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<CommonResponse> logout(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
-            HttpServletResponse response) {
-        jwtFacade.logout(response, userPrincipal.getUser().getIdentifier());
+    public ResponseEntity<CommonResponse> logout(@GitGetUser User user, HttpServletResponse response) {
+        jwtFacade.logout(response, user.getIdentifier());
 
         return ResponseEntity.ok().body(
                 new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage())

--- a/src/main/java/com/genius/gitget/global/util/annotation/GitGetUser.java
+++ b/src/main/java/com/genius/gitget/global/util/annotation/GitGetUser.java
@@ -1,0 +1,13 @@
+package com.genius.gitget.global.util.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface GitGetUser {
+}

--- a/src/main/java/com/genius/gitget/profile/controller/ProfileController.java
+++ b/src/main/java/com/genius/gitget/profile/controller/ProfileController.java
@@ -2,7 +2,8 @@ package com.genius.gitget.profile.controller;
 
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
 import com.genius.gitget.profile.dto.UserChallengeResultResponse;
@@ -18,7 +19,6 @@ import com.genius.gitget.profile.dto.UserSignoutRequest;
 import com.genius.gitget.profile.service.ProfileFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,9 +35,8 @@ public class ProfileController {
     // 마이페이지 - 사용자 상세 정보 조회
     @GetMapping
     public ResponseEntity<SingleResponse<UserDetailsInformationResponse>> getUserDetailsInformation(
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        UserDetailsInformationResponse userInformation = profileFacade.getUserDetailsInformation(
-                userPrincipal.getUser());
+            @GitGetUser User user) {
+        UserDetailsInformationResponse userInformation = profileFacade.getUserDetailsInformation(user);
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(),
                         userInformation)
@@ -58,10 +57,10 @@ public class ProfileController {
     // 마이페이지 - 회원 정보 수정
     @PostMapping("/information")
     public ResponseEntity<SingleResponse<UserIndexResponse>> updateUserInformation(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestBody UserInformationUpdateRequest userInformationUpdateRequest) {
 
-        Long userId = profileFacade.updateUserInformation(userPrincipal.getUser(), userInformationUpdateRequest);
+        Long userId = profileFacade.updateUserInformation(user, userInformationUpdateRequest);
         UserIndexResponse userIndexResponse = new UserIndexResponse(userId);
 
         return ResponseEntity.ok().body(
@@ -71,9 +70,8 @@ public class ProfileController {
 
     // 마이페이지 - 관심사 조회
     @GetMapping("/interest")
-    public ResponseEntity<SingleResponse<UserInterestResponse>> getUserInterest(
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        UserInterestResponse userInterest = profileFacade.getUserInterest(userPrincipal.getUser());
+    public ResponseEntity<SingleResponse<UserInterestResponse>> getUserInterest(@GitGetUser User user) {
+        UserInterestResponse userInterest = profileFacade.getUserInterest(user);
 
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(),
@@ -83,9 +81,9 @@ public class ProfileController {
 
     // 마이페이지 - 관심사 수정
     @PostMapping("/interest")
-    public ResponseEntity<CommonResponse> updateUserTags(@AuthenticationPrincipal UserPrincipal userPrincipal,
+    public ResponseEntity<CommonResponse> updateUserTags(@GitGetUser User user,
                                                          @RequestBody UserInterestUpdateRequest userInterestUpdateRequest) {
-        profileFacade.updateUserTags(userPrincipal.getUser(), userInterestUpdateRequest);
+        profileFacade.updateUserTags(user, userInterestUpdateRequest);
 
         return ResponseEntity.ok()
                 .body(new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage()));
@@ -94,10 +92,9 @@ public class ProfileController {
 
     // 마이페이지 - 챌린지 현황
     @GetMapping("/challenges")
-    public ResponseEntity<SingleResponse<UserChallengeResultResponse>> getUserChallengeResult(
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        UserChallengeResultResponse userChallengeResult = profileFacade.getUserChallengeResult(
-                userPrincipal.getUser());
+    public ResponseEntity<SingleResponse<UserChallengeResultResponse>> getUserChallengeResult(@GitGetUser User user) {
+        UserChallengeResultResponse userChallengeResult = profileFacade.getUserChallengeResult(user);
+
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(),
                         userChallengeResult));
@@ -106,9 +103,9 @@ public class ProfileController {
 
     // 마이페이지 - 탈퇴하기
     @DeleteMapping
-    public ResponseEntity<CommonResponse> deleteUserInformation(@AuthenticationPrincipal UserPrincipal userPrincipal,
+    public ResponseEntity<CommonResponse> deleteUserInformation(@GitGetUser User user,
                                                                 @RequestBody UserSignoutRequest userSignoutRequest) {
-        profileFacade.deleteUserInformation(userPrincipal.getUser(), userSignoutRequest.getReason());
+        profileFacade.deleteUserInformation(user, userSignoutRequest.getReason());
 
         return ResponseEntity.ok()
                 .body(new CommonResponse(SUCCESS.getStatus(), SUCCESS.getMessage()));
@@ -117,9 +114,8 @@ public class ProfileController {
 
     // 포인트 조회
     @GetMapping("/point")
-    public ResponseEntity<SingleResponse<UserPointResponse>> getUserPoint(
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        UserPointResponse userPoint = profileFacade.getUserPoint(userPrincipal.getUser());
+    public ResponseEntity<SingleResponse<UserPointResponse>> getUserPoint(@GitGetUser User user) {
+        UserPointResponse userPoint = profileFacade.getUserPoint(user);
 
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(),

--- a/src/main/java/com/genius/gitget/store/item/controller/StoreController.java
+++ b/src/main/java/com/genius/gitget/store/item/controller/StoreController.java
@@ -3,7 +3,8 @@ package com.genius.gitget.store.item.controller;
 import static com.genius.gitget.global.util.exception.SuccessCode.SUCCESS;
 
 import com.genius.gitget.challenge.certification.util.DateUtil;
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.ListResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
@@ -16,7 +17,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,15 +29,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class StoreController {
     private final StoreFacade storeFacade;
-//    private final ItemService itemService;
 
     @GetMapping("/items")
     public ResponseEntity<ListResponse<ItemResponse>> getItemList(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestParam String category
     ) {
         ItemCategory itemCategory = ItemCategory.findCategory(category);
-        List<ItemResponse> itemResponses = storeFacade.getItemsByCategory(userPrincipal.getUser(), itemCategory);
+        List<ItemResponse> itemResponses = storeFacade.getItemsByCategory(user, itemCategory);
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), itemResponses)
@@ -46,10 +45,10 @@ public class StoreController {
 
     @PostMapping("/items/order/{identifier}")
     public ResponseEntity<SingleResponse<ItemResponse>> purchaseItem(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable int identifier
     ) {
-        ItemResponse itemResponse = storeFacade.orderItem(userPrincipal.getUser(), identifier);
+        ItemResponse itemResponse = storeFacade.orderItem(user, identifier);
 
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), itemResponse)
@@ -58,11 +57,11 @@ public class StoreController {
 
     @PostMapping("/items/use/{identifier}")
     public ResponseEntity<CommonResponse> useItem(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @PathVariable int identifier,
             @RequestParam(required = false) Long instanceId
     ) {
-        OrderResponse orderResponse = storeFacade.useItem(userPrincipal.getUser(), identifier,
+        OrderResponse orderResponse = storeFacade.useItem(user, identifier,
                 instanceId, DateUtil.convertToKST(LocalDateTime.now()));
 
         return ResponseEntity.ok().body(
@@ -71,10 +70,8 @@ public class StoreController {
     }
 
     @PostMapping("/items/unuse")
-    public ResponseEntity<ListResponse<ProfileResponse>> unmountItem(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
-    ) {
-        List<ProfileResponse> profileResponses = storeFacade.unmountFrame(userPrincipal.getUser());
+    public ResponseEntity<ListResponse<ProfileResponse>> unmountItem(@GitGetUser User user) {
+        List<ProfileResponse> profileResponses = storeFacade.unmountFrame(user);
 
         return ResponseEntity.ok().body(
                 new ListResponse<>(SUCCESS.getStatus(), SUCCESS.getMessage(), profileResponses)

--- a/src/main/java/com/genius/gitget/store/payment/controller/PaymentController.java
+++ b/src/main/java/com/genius/gitget/store/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package com.genius.gitget.store.payment.controller;
 
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.exception.SuccessCode;
 import com.genius.gitget.global.util.response.dto.PagingResponse;
 import com.genius.gitget.store.payment.dto.PaymentDetailsResponse;
@@ -11,7 +12,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,13 +25,11 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @GetMapping
-    public ResponseEntity<PagingResponse<PaymentDetailsResponse>> getPaymentDetails(@AuthenticationPrincipal
-                                                                                    UserPrincipal userPrincipal,
+    public ResponseEntity<PagingResponse<PaymentDetailsResponse>> getPaymentDetails(@GitGetUser User user,
                                                                                     @PageableDefault
                                                                                     Pageable pageable) {
 
-        Page<PaymentDetailsResponse> paymentDetails = paymentService.getPaymentDetails(userPrincipal.getUser(),
-                pageable);
+        Page<PaymentDetailsResponse> paymentDetails = paymentService.getPaymentDetails(user, pageable);
 
         return ResponseEntity.ok().body(
                 new PagingResponse<>(SuccessCode.SUCCESS.getStatus(), SuccessCode.SUCCESS.getMessage(), paymentDetails)

--- a/src/main/java/com/genius/gitget/store/payment/controller/PaymentTossController.java
+++ b/src/main/java/com/genius/gitget/store/payment/controller/PaymentTossController.java
@@ -1,6 +1,7 @@
 package com.genius.gitget.store.payment.controller;
 
-import com.genius.gitget.global.security.domain.UserPrincipal;
+import com.genius.gitget.challenge.user.domain.User;
+import com.genius.gitget.global.util.annotation.GitGetUser;
 import com.genius.gitget.global.util.exception.SuccessCode;
 import com.genius.gitget.global.util.response.dto.CommonResponse;
 import com.genius.gitget.global.util.response.dto.SingleResponse;
@@ -13,7 +14,6 @@ import com.genius.gitget.store.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,9 +29,9 @@ public class PaymentTossController {
 
     @PostMapping
     public ResponseEntity<SingleResponse<PaymentResponse>> requestTossPayment(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @GitGetUser User user,
             @RequestBody PaymentRequest paymentRequest) {
-        PaymentResponse paymentResponse = paymentService.requestTossPayment(userPrincipal.getUser(), paymentRequest);
+        PaymentResponse paymentResponse = paymentService.requestTossPayment(user, paymentRequest);
         return ResponseEntity.ok().body(
                 new SingleResponse<>(SuccessCode.SUCCESS.getStatus(), SuccessCode.SUCCESS.getMessage(), paymentResponse)
         );


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`feat/248-auth-custom-annotation` → `main`

</br>

### 변경 사항
> `@AuthenticationPrincipal` 어노테이션의 중복 코드를 제거하기 위해 `@GitGetUser` 커스텀 어노테이션을 작성하고 적용합니다.

#### 작업 상세 내용
- [x] `@GitGetUser` 커스텀 어노테이션 작성
- [x] 컨트롤러 코드 중, `@AuthenticationPrincipal` 어노테이션 대신 `@GitGetUser` 어노테이션으로 변경

</br>

### 테스트 결과
![image](https://github.com/user-attachments/assets/daf71c9d-5c9f-4745-beac-cfbe228d585f)

</br>

### 연관된 이슈
#248 

</br>

### 리뷰 요구사항(선택)
> 
