### PR TITLE
[FIX] 회원 탈퇴 이후, 로그인 버튼을 눌렀을 때 회원가입 페이지로 가지 않는 버그 픽스

### DIFF
--- a/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
+++ b/src/main/java/com/genius/gitget/challenge/user/service/UserService.java
@@ -58,6 +58,7 @@ public class UserService {
     }
 
 
+    @Transactional
     public void delete(Long userId, String identifier, String reason) {
         userRepository.deleteById(userId);
         signoutRepository.save(

--- a/src/main/java/com/genius/gitget/profile/service/ProfileFacadeService.java
+++ b/src/main/java/com/genius/gitget/profile/service/ProfileFacadeService.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class ProfileFacadeService implements ProfileFacade {
@@ -75,6 +76,7 @@ public class ProfileFacadeService implements ProfileFacade {
     }
 
     @Override
+    @Transactional
     public Long updateUserInformation(User user, UserInformationUpdateRequest userInformationUpdateRequest) {
         User findUser = userService.findUserByIdentifier(user.getIdentifier());
         findUser.updateUserInformation(
@@ -85,6 +87,7 @@ public class ProfileFacadeService implements ProfileFacade {
     }
 
     @Override
+    @Transactional
     public void deleteUserInformation(User user, String reason) {
         User findUser = userService.findUserByIdentifier(user.getIdentifier());
 
@@ -96,6 +99,7 @@ public class ProfileFacadeService implements ProfileFacade {
     }
 
     @Override
+    @Transactional
     public void updateUserTags(User user, UserInterestUpdateRequest userInterestUpdateRequest) {
         if (userInterestUpdateRequest.getTags() == null) {
             throw new BusinessException();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
□ 기능 추가

□ 기능 삭제

☑ 버그 수정

□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`fix/261-member-withdrawal-bug` → `main`

</br>

### 변경 사항
- [x] 회원 탈퇴 이후, 로그인 버튼을 눌렀을 때 회원가입 페이지로 가지 않는 버그 픽스
    - [x] ProfileFacadeService, UserService의 Dirty checking이 필요한 메서드에 대해 @Transactional 어노테이션 추가

</br>

### 테스트 결과
![image](https://github.com/user-attachments/assets/99e72014-0d5a-474a-96dd-eca7a50fd4c5)


</br>

### 연관된 이슈
#261 

</br>

### 리뷰 요구사항(선택)
> 