### PR TITLE
[REFACTOR] 파일 시스템 버전에 따른 로직 분리

### DIFF
--- a/src/main/java/com/genius/gitget/global/file/dto/FileEnv.java
+++ b/src/main/java/com/genius/gitget/global/file/dto/FileEnv.java
@@ -1,0 +1,19 @@
+package com.genius.gitget.global.file.dto;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FileEnv {
+    private static Environment environment;
+
+    @Autowired
+    public FileEnv(Environment env) {
+        environment = env;
+    }
+
+    public static String getFileEnvironment() {
+        return environment.getProperty("file.mode").toUpperCase();
+    }
+}

--- a/src/main/java/com/genius/gitget/global/file/dto/FileResponse.java
+++ b/src/main/java/com/genius/gitget/global/file/dto/FileResponse.java
@@ -2,13 +2,14 @@ package com.genius.gitget.global.file.dto;
 
 public record FileResponse(
         Long fileId,
-        String accessURI) {
+        String source,
+        String environment) {
 
     public static FileResponse createExistFile(Long filesId, String accessURI) {
-        return new FileResponse(filesId, accessURI);
+        return new FileResponse(filesId, accessURI, FileEnv.getFileEnvironment());
     }
 
     public static FileResponse createNotExistFile() {
-        return new FileResponse(0L, "");
+        return new FileResponse(0L, "", FileEnv.getFileEnvironment());
     }
 }

--- a/src/main/java/com/genius/gitget/global/file/service/LocalFileService.java
+++ b/src/main/java/com/genius/gitget/global/file/service/LocalFileService.java
@@ -13,8 +13,11 @@ import com.genius.gitget.global.file.dto.UpdateDTO;
 import com.genius.gitget.global.util.exception.BusinessException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.StandardCopyOption;
+import java.util.Base64;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.UrlResource;
 import org.springframework.web.multipart.MultipartFile;
 
 public class LocalFileService implements FileService {
@@ -45,7 +48,13 @@ public class LocalFileService implements FileService {
 
     @Override
     public String getFileAccessURI(Files files) {
-        return files.getFileURI();
+        try {
+            UrlResource urlResource = new UrlResource("file:" + files.getFileURI());
+            byte[] encode = Base64.getEncoder().encode(urlResource.getContentAsByteArray());
+            return new String(encode, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "";
+        }
     }
 
     @Override

--- a/src/main/java/com/genius/gitget/global/file/service/S3FileService.java
+++ b/src/main/java/com/genius/gitget/global/file/service/S3FileService.java
@@ -13,7 +13,6 @@ import com.genius.gitget.global.file.dto.FileDTO;
 import com.genius.gitget.global.file.dto.UpdateDTO;
 import com.genius.gitget.global.util.exception.BusinessException;
 import java.io.IOException;
-import java.net.URL;
 import org.springframework.web.multipart.MultipartFile;
 
 public class S3FileService implements FileService {
@@ -21,6 +20,7 @@ public class S3FileService implements FileService {
     private final FileUtil fileUtil;
     private final String bucket;
     private final String cloudFrontDomain;
+
     public S3FileService(AmazonS3 amazonS3, FileUtil fileUtil, String bucket, String cloudFrontDomain) {
         this.amazonS3 = amazonS3;
         this.fileUtil = fileUtil;
@@ -30,8 +30,7 @@ public class S3FileService implements FileService {
 
     @Override
     public String getFileAccessURI(Files files) {
-        URL url = amazonS3.getUrl(bucket, files.getFileURI());
-        return cloudFrontDomain + url.getFile();
+        return cloudFrontDomain + files.getFileURI();
     }
 
     @Override

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -44,9 +44,8 @@ FROM (SELECT 1                      AS identifier,
              'PROFILE_FRAME') AS new_items
 WHERE (SELECT COUNT(*) FROM item) < 3;
 
-INSERT INTO users (`point`, user_id, nickname, information, identifier, tags, provider_info, `role`)
+INSERT INTO users (`point`, nickname, information, identifier, tags, provider_info, `role`)
 SELECT 0,
-       104,
        'Guest',
        '자기 소개입니다.',
        'Guest',

--- a/src/test/java/com/genius/gitget/global/file/domain/FilesTest.java
+++ b/src/test/java/com/genius/gitget/global/file/domain/FilesTest.java
@@ -20,13 +20,13 @@ class FilesTest {
                 .fileType(FileType.INSTANCE)
                 .originalFilename("originalFilename")
                 .savedFilename("savedFilename")
-                .fileURI("accessURI")
+                .fileURI("source")
                 .build();
 
         UpdateDTO updateDTO = UpdateDTO.builder()
                 .savedFilename("new savedFilename")
                 .originalFilename("new originalFilename")
-                .fileURI("new accessURI")
+                .fileURI("new source")
                 .build();
 
         //when


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
☑ 기능 추가
□ 기능 삭제
□ 버그 수정
□ 의존성, 환경 변수, 빌드 관련 코드 업데이트

</br>

### 반영 브랜치
`refactor/270-file-response-fields` -> `main`

</br>

### 변경 사항
> Local 버전과 Production 버전에 따라 파일을 처리하는 로직을 분리합니다.
> Local 버전에서도 기존에 파일 URI를 반환하던 방식에서 Base64로 인코딩 한 문자열을 반환하는 방식으로 변경합니다.
> Production 버전에서는 이전 방식에서 변경하지 않습니다.

#### 작업 상세 내용
- [x] FileReponse 응답 데이터 구조 변경
    - [x] 필드 중 하나인 accessURI를 source로 변경
    - [x] 파일 응답 데이터가 Local인지 Production인지 구분하는 Environment 필드 추가
- [x] Local 버전에서는 source 필드에 Base64로 인코딩한 문자열을 반환하도록 변경

</br>

### 테스트 결과
![image](https://github.com/user-attachments/assets/e9a0fad4-59d7-4901-a6f7-b17125a22784)

</br>

### 연관된 이슈
#270 

</br>

### 리뷰 요구사항(선택)
> 
